### PR TITLE
 Fix type error for port argument to AppManager

### DIFF
--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -107,7 +107,7 @@ class AppManager(object):
         config = ru.read_json(os.path.join(config_path, 'config.json'))
 
         self._mq_hostname = hostname if hostname else str(config['hostname'])
-        self._port = port if port else config['port']
+        self._port = int(port if port else config['port'])
         self._reattempts = reattempts if reattempts else config['reattempts']
         self._resubmit_failed = resubmit_failed if resubmit_failed is not None else config['resubmit_failed']
         self._autoterminate = autoterminate if autoterminate is not None else config['autoterminate']


### PR DESCRIPTION
I am getting `Error in AppManager: Expected (base) type(s) <type 'int'>, but got <type 'str'>` when I run examples from the user guide on rtd.  I think you didn't have the issue because you hadn't exported the `RMQ_PORT` environment variable.