### PR TITLE
fix resolve_args + bring back resolve_tags + tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ script:
   - coverage run -m pytest -vvv tests/test_component/test_stage.py
   - coverage run -m pytest -vvv tests/test_component/test_task.py
   - coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py
-  - coverage run -m pytest -vvv tests/test_component/test_tmgr_rp_utils_2.py
-  - coverage run -m pytest -vvv tests/test_component/test_tmgr_rp_utils.py
+  - coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py
+  - coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py
   - coverage run -m pytest -vvv tests/test_component/test_tmgr.py
   - coverage run -m pytest -vvv tests/test_component/test_wfp.py
   - coverage run -m pytest -vvv tests/test_component/test_states.py

--- a/examples/misc/lfs_tagging_dd.py
+++ b/examples/misc/lfs_tagging_dd.py
@@ -30,7 +30,7 @@ def get_pipeline(shared_fs=False, size=1):
         else:
             t.arguments = ['if=/dev/urandom','bs=%sM'%size, 'count=1', 'of=/home/vivek91/s1_t%s.txt'%x]
 
-        t.cpu_reqs['processes'] = 1        
+        t.cpu_reqs['processes'] = 1
         t.cpu_reqs['threads_per_process'] = 24
         t.cpu_reqs['thread_type'] = ''
         t.cpu_reqs['process_type'] = ''
@@ -60,7 +60,7 @@ def get_pipeline(shared_fs=False, size=1):
         s2.add_tasks(t)
 
 
-    p.add_stages(s2)    
+    p.add_stages(s2)
 
     return p
 
@@ -90,11 +90,11 @@ if __name__ == '__main__':
                 'project'       : 'unc100'
                 # 'project'       : 'gk4',
                 # 'queue'         : 'high'
-            }    
+            }
 
     appman = AppManager(hostname=hostname, port=port)
     appman.resource_desc = res_dict
 
     p = get_pipeline(shared_fs=shared_fs, size=size)
     appman.workflow = [p]
-    appman.run()    
+    appman.run()

--- a/src/radical/entk/execman/rp/task_processor.py
+++ b/src/radical/entk/execman/rp/task_processor.py
@@ -49,14 +49,14 @@ def resolve_placeholders(path, placeholder_dict):
         if not len(broken_placeholder) == 6:
             raise ValueError(
                 obj='placeholder',
-                attribute='segments',
+                attribute='task',
                 expected_value='$Pipeline_(pipeline_name)_Stage_(stage_name)_Task_(task_name) or $SHARED',
                 actual_value=broken_placeholder)
 
         pipeline_name = broken_placeholder[1]
         stage_name = broken_placeholder[3]
         task_name = broken_placeholder[5]
-        resolve_placeholder = None
+        resolved_placeholder = None
 
         if pipeline_name in placeholder_dict.keys():
             if stage_name in placeholder_dict[pipeline_name].keys():
@@ -72,14 +72,14 @@ def resolve_placeholders(path, placeholder_dict):
         else:
             logger.warning('%s not assigned to any Pipeline' % (pipeline_name))
 
-        if not resolve_placeholder:
+        if not resolved_placeholder:
             logger.warning('No placeholder could be found for task name %s \
                         stage name %s and pipeline name %s. Please be sure to \
                         use object names and not uids in your references,i.e, \
                         $Pipeline_(pipeline_name)_Stage_(stage_name)_Task_(task_name)')
             raise ValueError(
                 obj='placeholder',
-                attribute='segments',
+                attribute='task',
                 expected_value='$Pipeline_(pipeline_name)_Stage_(stage_name)_Task_(task_name) or $SHARED',
                 actual_value=broken_placeholder)
 

--- a/src/radical/entk/execman/rp/task_processor.py
+++ b/src/radical/entk/execman/rp/task_processor.py
@@ -49,13 +49,14 @@ def resolve_placeholders(path, placeholder_dict):
         if not len(broken_placeholder) == 6:
             raise ValueError(
                 obj='placeholder',
-                attribute='length',
-                expected_value='$Pipeline_{pipeline.uid}_Stage_{stage.uid}_Task_{task.uid} or $SHARED',
+                attribute='segments',
+                expected_value='$Pipeline_(pipeline_name)_Stage_(stage_name)_Task_(task_name) or $SHARED',
                 actual_value=broken_placeholder)
 
         pipeline_name = broken_placeholder[1]
         stage_name = broken_placeholder[3]
         task_name = broken_placeholder[5]
+        resolve_placeholder = None
 
         if pipeline_name in placeholder_dict.keys():
             if stage_name in placeholder_dict[pipeline_name].keys():
@@ -70,6 +71,17 @@ def resolve_placeholders(path, placeholder_dict):
                     stage_name, pipeline_name))
         else:
             logger.warning('%s not assigned to any Pipeline' % (pipeline_name))
+
+        if not resolve_placeholder:
+            logger.warning('No placeholder could be found for task name %s \
+                        stage name %s and pipeline name %s. Please be sure to \
+                        use object names and not uids in your references,i.e, \
+                        $Pipeline_(pipeline_name)_Stage_(stage_name)_Task_(task_name)')
+            raise ValueError(
+                obj='placeholder',
+                attribute='segments',
+                expected_value='$Pipeline_(pipeline_name)_Stage_(stage_name)_Task_(task_name) or $SHARED',
+                actual_value=broken_placeholder)
 
         return resolved_placeholder
 

--- a/tests/test_component/test_tproc_rp.py
+++ b/tests/test_component/test_tproc_rp.py
@@ -260,28 +260,28 @@ def test_create_cud_from_task():
     assert {'source': 'download_output.dat', 'target': 'download_output.dat'} in cud.output_staging
 
 
-# def test_create_task_from_cu():
-#     """
-#     **Purpose**: Test if the 'create_task_from_cu' function generates a Task with the correct uid, parent_stage and
-#     parent_pipeline from a RP ComputeUnit
-#     """
+def test_create_task_from_cu():
+    """
+    **Purpose**: Test if the 'create_task_from_cu' function generates a Task with the correct uid, parent_stage and
+    parent_pipeline from a RP ComputeUnit
+    """
 
-#     session = rp.Session(dburl=MLAB)
-#     umgr = rp.UnitManager(session=session)
-#     cud = rp.ComputeUnitDescription()
-#     cud.name = 'uid, name, parent_stage_uid, parent_stage_name, parent_pipeline_uid, parent_pipeline_name'
-#     cud.executable = '/bin/echo'
+    session = rp.Session(dburl=MLAB)
+    umgr = rp.UnitManager(session=session)
+    cud = rp.ComputeUnitDescription()
+    cud.name = 'uid, name, parent_stage_uid, parent_stage_name, parent_pipeline_uid, parent_pipeline_name'
+    cud.executable = '/bin/echo'
 
-#     cu = rp.ComputeUnit(umgr, cud)
+    cu = rp.ComputeUnit(umgr, cud)
 
-#     t = create_task_from_cu(cu)
+    t = create_task_from_cu(cu)
 
-#     assert t.uid == 'uid'
-#     assert t.name == 'name'
-#     assert t.parent_stage['uid'] == 'parent_stage_uid'
-#     assert t.parent_stage['name'] == 'parent_stage_name'
-#     assert t.parent_pipeline['uid'] == 'parent_pipeline_uid'
-#     assert t.parent_pipeline['name'] == 'parent_pipeline_name'
+    assert t.uid == 'uid'
+    assert t.name == 'name'
+    assert t.parent_stage['uid'] == 'parent_stage_uid'
+    assert t.parent_stage['name'] == 'parent_stage_name'
+    assert t.parent_pipeline['uid'] == 'parent_pipeline_uid'
+    assert t.parent_pipeline['name'] == 'parent_pipeline_name'
 
 
 def test_resolve_placeholder():

--- a/tests/test_component/test_tproc_rp_2.py
+++ b/tests/test_component/test_tproc_rp_2.py
@@ -1,4 +1,4 @@
-from radical.entk.execman.rp.task_processor import create_task_from_cu, resolve_arguments
+from radical.entk.execman.rp.task_processor import create_task_from_cu, resolve_arguments, resolve_tags
 from radical.entk.exceptions import *
 from radical.entk import Task, Stage, Pipeline
 import radical.pilot as rp
@@ -38,19 +38,19 @@ def test_create_task_from_cu():
 
 def test_resolve_args():
 
-    pipeline = str(ru.generate_id('pipeline'))
-    stage = str(ru.generate_id('stage'))
-    t1 = str(ru.generate_id('task'))
-    t2 = str(ru.generate_id('task'))
+    pipeline_name = 'p1'
+    stage_name = 's1'
+    t1_name = 't1'
+    t2_name = 't2'
 
     placeholder_dict = {
-        pipeline: {
-            stage: {
-                t1: {
+        pipeline_name: {
+            stage_name: {
+                t1_name: {
                     'path': '/home/vivek/t1',
                     'rts_uid': 'unit.0002'
                 },
-                t2: {
+                t2_name: {
                     'path': '/home/vivek/t2',
                     'rts_uid': 'unit.0003'
                 }
@@ -59,9 +59,43 @@ def test_resolve_args():
     }
 
     arguments = ['$SHARED',
-                 '$Pipeline_%s_Stage_%s_Task_%s' % (pipeline, stage, t1),
-                 '$Pipeline_%s_Stage_%s_Task_%s' % (pipeline, stage, t2)]
+                 '$Pipeline_%s_Stage_%s_Task_%s' % (pipeline_name, stage_name, t1_name),
+                 '$Pipeline_%s_Stage_%s_Task_%s' % (pipeline_name, stage_name, t2_name),
+                 '$NODE_LFS_PATH/test.txt']
 
     assert resolve_arguments(arguments, placeholder_dict) == ['$RP_PILOT_STAGING',
                                                               '/home/vivek/t1',
-                                                              '/home/vivek/t2']
+                                                              '/home/vivek/t2',
+                                                              '$NODE_LFS_PATH/test.txt']
+
+
+def test_resolve_tags():
+
+    pipeline_name = 'p1'
+    stage_name = 's1'
+    t1_name = 't1'
+    t2_name = 't2'
+
+    placeholder_dict = {
+        pipeline_name: {
+            stage_name: {
+                t1_name: {
+                    'path': '/home/vivek/t1',
+                    'rts_uid': 'unit.0002'
+                },
+                t2_name: {
+                    'path': '/home/vivek/t2',
+                    'rts_uid': 'unit.0003'
+                }
+            }
+        }
+    }
+
+    assert resolve_tags(tag=t1_name,
+                        parent_pipeline_name=pipeline_name,
+                        placeholder_dict=placeholder_dict) == 'unit.0002'
+
+    with pytest.raises(EnTKError):
+        resolve_tags(   tag='t3',
+                        parent_pipeline_name=pipeline_name,
+                        placeholder_dict=placeholder_dict) == 'unit.0002'


### PR DESCRIPTION
This PR fixes https://github.com/radical-cybertools/radical.entk/issues/286. Does the following: 
* parsing the argument and only resolves if the string has '$SHARED' or '$Pipeline', ignores rest.
* brings back resolve_tags method that seems to have been lost in an earlier merge
* tests resolve_args (if it indeed ignores) and resolve_tags()