### PR TITLE
moved task processing and submission to another thread

### DIFF
--- a/examples/simple_examples/poe.py
+++ b/examples/simple_examples/poe.py
@@ -13,7 +13,7 @@ if os.environ.get('RADICAL_ENTK_VERBOSE') == None:
 # VM, set "RMQ_HOSTNAME" and "RMQ_PORT" in the session where you are running
 # this script.
 hostname = os.environ.get('RMQ_HOSTNAME', 'localhost')
-port = os.environ.get('RMQ_PORT', 5672)
+port = int(os.environ.get('RMQ_PORT', 5672))
 
 
 def generate_pipeline():
@@ -51,7 +51,7 @@ def generate_pipeline():
         t2.executable = ['/bin/bash']
         t2.arguments = ['-l', '-c', 'grep -o . output.txt | sort | uniq -c > ccount.txt']
         # Copy data from the task in the first stage to the current task's location
-        t2.copy_input_data = ['$Pipline_%s_Stage_%s_Task_%s/output.txt' % (p.name, s1.name, t1.name)]
+        t2.copy_input_data = ['$Pipeline_%s_Stage_%s_Task_%s/output.txt' % (p.name, s1.name, t1.name)]
 
         # Add the Task to the Stage
         s2.add_tasks(t2)
@@ -72,7 +72,7 @@ def generate_pipeline():
         t3.executable = ['/bin/bash']
         t3.arguments = ['-l', '-c', 'sha1sum ccount.txt > chksum.txt']
         # Copy data from the task in the first stage to the current task's location
-        t3.copy_input_data = ['$Pipline_%s_Stage_%s_Task_%s/ccount.txt' % (p.name, s2.name, s2_task_uids[cnt])]
+        t3.copy_input_data = ['$Pipeline_%s_Stage_%s_Task_%s/ccount.txt' % (p.name, s2.name, s2_task_uids[cnt])]
         # Download the output of the current task to the current location
         t3.download_output_data = ['chksum.txt > chksum_%s.txt' % cnt]
 
@@ -87,7 +87,7 @@ def generate_pipeline():
 if __name__ == '__main__':
 
     # Create Application Manager
-    appman = AppManager(hostname=hostname, port=port)
+    appman = AppManager(hostname=hostname, port=port, rts='mock')
 
     # Create a dictionary describe four mandatory keys:
     # resource, walltime, and cpus

--- a/src/radical/entk/execman/base/task_manager.py
+++ b/src/radical/entk/execman/base/task_manager.py
@@ -70,7 +70,7 @@ class Base_TaskManager(object):
         if isinstance(rmgr, Base_ResourceManager):
             self._rmgr = rmgr
         else:
-            raise TypeError(expected_type=ResourceManager, actual_type=type(rmgr))
+            raise TypeError(expected_type=Base_ResourceManager, actual_type=type(rmgr))
 
         self._rts = rts
 

--- a/src/radical/entk/execman/rp/task_manager.py
+++ b/src/radical/entk/execman/rp/task_manager.py
@@ -15,6 +15,8 @@ import os
 import radical.pilot as rp
 from task_processor import create_cud_from_task, create_task_from_cu
 from ..base.task_manager import Base_TaskManager
+import Queue
+import traceback
 
 
 class TaskManager(Base_TaskManager):
@@ -37,17 +39,18 @@ class TaskManager(Base_TaskManager):
     """
 
     def __init__(self, sid, pending_queue, completed_queue,
-                rmgr, mq_hostname, port):
+                 rmgr, mq_hostname, port):
 
         super(TaskManager, self).__init__(sid,
-                                        pending_queue,
-                                        completed_queue,
-                                        rmgr,
-                                        mq_hostname,
-                                        port,
-                                        rts='radical.pilot')
+                                          pending_queue,
+                                          completed_queue,
+                                          rmgr,
+                                          mq_hostname,
+                                          port,
+                                          rts='radical.pilot')
 
         self._umgr = None
+        self._rts_runner = None
         self._rmq_ping_interval = os.getenv('RMQ_PING_INTERVAL', 10)
         self._logger.info('Created task manager object: %s' % self._uid)
         self._prof.prof('tmgr obj created', uid=self._uid)
@@ -74,113 +77,60 @@ class TaskManager(Base_TaskManager):
 
         try:
 
-            local_prof = ru.Profiler(name='radical.entk.%s' % self._uid + '-proc', path=self._path)
-
-            local_prof.prof('tmgr process started', uid=self._uid)
-            logger.info('Task Manager process started')
-
-            placeholder_dict = dict()
-
-            def load_placeholder(task, rts_uid):
-
-                parent_pipeline = str(task.parent_pipeline['name'])
-                parent_stage = str(task.parent_stage['name'])
-
-                if parent_pipeline not in placeholder_dict:
-                    placeholder_dict[parent_pipeline] = dict()
-
-                if parent_stage not in placeholder_dict[parent_pipeline]:
-                    placeholder_dict[parent_pipeline][parent_stage] = dict()
-
-                if None not in [parent_pipeline, parent_stage, task.name]:
-                    placeholder_dict[parent_pipeline][parent_stage][str(task.name)] = {'path': str(task.path),
-                                                                                        'rts_uid': rts_uid}
-
             def heartbeat_response(mq_channel):
 
                 try:
 
                     # Get request from heartbeat-req for heartbeat response
-                    hb_method_frame, hb_props, hb_body = mq_channel.basic_get(queue=self._hb_request_q)
+                    hb_method_frame, hb_props, hb_body = mq_channel.basic_get(
+                        queue=self._hb_request_q)
 
                     if hb_body:
 
                         logger.info('Received heartbeat request')
 
                         mq_channel.basic_publish(exchange='',
-                                                routing_key=self._hb_response_q,
-                                                properties=pika.BasicProperties(correlation_id=hb_props.correlation_id),
-                                                body='response')
+                                                 routing_key=self._hb_response_q,
+                                                 properties=pika.BasicProperties(
+                                                     correlation_id=hb_props.correlation_id),
+                                                 body='response')
 
                         logger.info('Sent heartbeat response')
-                        mq_channel.basic_ack(delivery_tag=hb_method_frame.delivery_tag)
+                        mq_channel.basic_ack(
+                            delivery_tag=hb_method_frame.delivery_tag)
 
                 except Exception, ex:
-                    logger.exception('Failed to respond to heartbeat request, error: %s' % ex)
+                    logger.exception(
+                        'Failed to respond to heartbeat request, error: %s' % ex)
                     raise
 
-            def unit_state_cb(unit, state):
-
-                try:
-
-                    logger.debug('Unit %s in state %s' % (unit.uid, unit.state))
-
-                    if unit.state in rp.FINAL:
-
-                        # Acquire a connection+channel to the rmq server
-                        mq_connection = pika.BlockingConnection(pika.ConnectionParameters(host=mq_hostname, port=port))
-                        mq_channel = mq_connection.channel()
-
-                        task = None
-                        task = create_task_from_cu(unit, local_prof)
-
-                        transition(obj=task,
-                                obj_type='Task',
-                                new_state=states.COMPLETED,
-                                channel=mq_channel,
-                                queue='%s-cb-to-sync' % self._sid,
-                                profiler=local_prof,
-                                logger=logger)
-
-                        load_placeholder(task, unit.uid)
-
-                        task_as_dict = json.dumps(task.to_dict())
-
-                        mq_channel.basic_publish(exchange='',
-                                                routing_key='%s-completedq-1' % self._sid,
-                                                body=task_as_dict
-                                                # properties=pika.BasicProperties(
-                                                # make message persistent
-                                                #    delivery_mode = 2,
-                                                #)
-                                                )
-
-                        logger.info('Pushed task %s with state %s to completed queue %s' % (task.uid, task.state,
-                                                                                            completed_queue[0]))
-
-                        mq_connection.close()
-
-                except KeyboardInterrupt:
-                    self._logger.exception('Execution interrupted by user (you probably hit Ctrl+C), ' +
-                                            'trying to exit callback thread gracefully...')
-
-                    raise KeyboardInterrupt
-
-                except Exception, ex:
-                    self._logger.exception('Error in RP callback thread: %s' % ex)
-
-            if not umgr:
-                umgr = rp.UnitManager(session=rmgr._session)
-                umgr.add_pilots(rmgr.pilot)
-                umgr.register_callback(unit_state_cb)
+            local_prof = ru.Profiler(
+                name='radical.entk.%s' % self._uid + '-proc', path=self._path)
+            local_prof.prof('tmgr process started', uid=self._uid)
+            logger.info('Task Manager process started')
 
             # Acquire a connection+channel to the rmq server
-            mq_connection = pika.BlockingConnection(pika.ConnectionParameters(host=mq_hostname, port=port))
+            mq_connection = pika.BlockingConnection(
+                pika.ConnectionParameters(host=mq_hostname, port=port))
             mq_channel = mq_connection.channel()
 
             # Make sure the heartbeat response queue is empty
             mq_channel.queue_delete(queue=self._hb_response_q)
             mq_channel.queue_declare(queue=self._hb_response_q)
+
+            # Queue for communication between threads of this process
+            task_queue = Queue.Queue()
+
+            # Start second thread to receive tasks and push to RTS
+            self._rts_runner = threading.Thread(target=self._process_tasks,
+                                                args=(task_queue,
+                                                      rmgr,
+                                                      logger,
+                                                      mq_hostname,
+                                                      port,
+                                                      local_prof,
+                                                      self._sid))
+            self._rts_runner.start()
 
             local_prof.prof('tmgr infrastructure setup done', uid=uid)
 
@@ -190,60 +140,16 @@ class TaskManager(Base_TaskManager):
                 try:
 
                     # Get tasks from the pending queue
-                    method_frame, header_frame, body = mq_channel.basic_get(queue=pending_queue[0])
+                    method_frame, header_frame, body = mq_channel.basic_get(
+                        queue=pending_queue[0])
 
                     if body:
 
                         body = json.loads(body)
-                        bulk_tasks = list()
-                        bulk_cuds = list()
+                        task_queue.put(body)
 
-                        for task in body:
-                            t = Task()
-                            t.from_dict(task)
-                            bulk_tasks.append(t)
-                            bulk_cuds.append(create_cud_from_task(t, placeholder_dict, local_prof))
-
-                            transition(obj=t,
-                                    obj_type='Task',
-                                    new_state=states.SUBMITTING,
-                                    channel=mq_channel,
-                                    queue='%s-tmgr-to-sync' % self._sid,
-                                    profiler=local_prof,
-                                    logger=self._logger)
-
-                        # To accommodate long cud creation times
-                        heartbeat_response(mq_channel)
-
-                        now = time.time()
-                        if now - last >= self._rmq_ping_interval:
-                            mq_connection.process_data_events()
-                            last = now
-
-                        umgr.submit_units(bulk_cuds)
-
-                        for task in bulk_tasks:
-
-                            transition(obj=task,
-                                    obj_type='Task',
-                                    new_state=states.SUBMITTED,
-                                    channel=mq_channel,
-                                    queue='%s-tmgr-to-sync' % self._sid,
-                                    profiler=local_prof,
-                                    logger=self._logger)
-                            self._logger.info('Task %s submitted to RTS' % (task.uid))
-
-
-                        # To accommodate long cud submission times
-                        heartbeat_response(mq_channel)
-
-                        # Appease pika cos it thinks the connection is dead
-                        now = time.time()
-                        if now - last >= self._rmq_ping_interval:
-                            mq_connection.process_data_events()
-                            last = now
-
-                        mq_channel.basic_ack(delivery_tag=method_frame.delivery_tag)
+                        mq_channel.basic_ack(
+                            delivery_tag=method_frame.delivery_tag)
 
                     heartbeat_response(mq_channel)
 
@@ -251,18 +157,155 @@ class TaskManager(Base_TaskManager):
                     logger.exception('Error in task execution: %s' % ex)
                     raise
 
-            local_prof.prof('terminating tmgr process', uid=uid)
-            mq_connection.close()
-            local_prof.close()
-
         except KeyboardInterrupt:
 
             self._logger.error('Execution interrupted by user (you probably hit Ctrl+C), ' +
-                                'trying to cancel tmgr process gracefully...')
-            raise KeyboardInterrupt
+                               'trying to cancel tmgr process gracefully...')
 
         except Exception, ex:
 
+            print traceback.format_exc()
+            raise EnTKError(ex)
+
+        finally:
+
+            local_prof.prof('terminating tmgr process', uid=uid)
+
+            if self._rts_runner:
+                self._rts_runner.join()
+
+            mq_connection.close()
+            local_prof.close()
+
+    def _process_tasks(self, task_queue, rmgr, logger, mq_hostname, port, local_prof, sid):
+
+        placeholder_dict = dict()
+
+        def load_placeholder(task, rts_uid):
+
+            parent_pipeline = str(task.parent_pipeline['name'])
+            parent_stage = str(task.parent_stage['name'])
+
+            if parent_pipeline not in placeholder_dict:
+                placeholder_dict[parent_pipeline] = dict()
+
+            if parent_stage not in placeholder_dict[parent_pipeline]:
+                placeholder_dict[parent_pipeline][parent_stage] = dict()
+
+            if None not in [parent_pipeline, parent_stage, task.name]:
+                placeholder_dict[parent_pipeline][parent_stage][str(task.name)] = {'path': str(task.path),
+                                                                                   'rts_uid': rts_uid}
+
+        def unit_state_cb(unit, state):
+
+            try:
+
+                logger.debug('Unit %s in state %s' % (unit.uid, unit.state))
+
+                if unit.state in rp.FINAL:
+
+                    # Acquire a connection+channel to the rmq server
+                    mq_connection = pika.BlockingConnection(
+                        pika.ConnectionParameters(host=mq_hostname, port=port))
+                    mq_channel = mq_connection.channel()
+
+                    task = None
+                    task = create_task_from_cu(unit, local_prof)
+
+                    transition(obj=task,
+                               obj_type='Task',
+                               new_state=states.COMPLETED,
+                               channel=mq_channel,
+                               queue='%s-cb-to-sync' % sid,
+                               profiler=local_prof,
+                               logger=logger)
+
+                    load_placeholder(task, unit.uid)
+
+                    task_as_dict = json.dumps(task.to_dict())
+
+                    mq_channel.basic_publish(exchange='',
+                                             routing_key='%s-completedq-1' % sid,
+                                             body=task_as_dict
+                                             # properties=pika.BasicProperties(
+                                             # make message persistent
+                                             #    delivery_mode = 2,
+                                             # )
+                                             )
+
+                    logger.info('Pushed task %s with state %s to completed queue %s-completedq-1' % (task.uid, task.state,
+                                                                                                     sid))
+
+                    mq_connection.close()
+
+            except KeyboardInterrupt:
+                logger.exception('Execution interrupted by user (you probably hit Ctrl+C), ' +
+                                 'trying to exit callback thread gracefully...')
+
+                raise KeyboardInterrupt
+
+            except Exception, ex:
+                logger.exception('Error in RP callback thread: %s' % ex)
+
+        umgr = rp.UnitManager(session=rmgr._session)
+        umgr.add_pilots(rmgr.pilot)
+        umgr.register_callback(unit_state_cb)
+
+        mq_connection = pika.BlockingConnection(
+            pika.ConnectionParameters(host=mq_hostname, port=port))
+        mq_channel = mq_connection.channel()
+
+        try:
+
+            while not self._tmgr_terminate.is_set():
+
+                body = None
+
+                try:
+                    body = task_queue.get(block=True, timeout=10)
+                except Queue.Empty:
+                    # Ignore empty exception, we don't always have new tasks to run
+                    pass
+
+                if body:
+
+                    task_queue.task_done()
+
+                    bulk_tasks = list()
+                    bulk_cuds = list()
+
+                    for task in body:
+                        t = Task()
+                        t.from_dict(task)
+                        bulk_tasks.append(t)
+                        bulk_cuds.append(create_cud_from_task(
+                            t, placeholder_dict, local_prof))
+
+                        transition(obj=t,
+                                   obj_type='Task',
+                                   new_state=states.SUBMITTING,
+                                   channel=mq_channel,
+                                   queue='%s-tmgr-to-sync' % sid,
+                                   profiler=local_prof,
+                                   logger=logger)
+
+                    umgr.submit_units(bulk_cuds)
+
+                    for task in bulk_tasks:
+
+                        transition(obj=task,
+                                   obj_type='Task',
+                                   new_state=states.SUBMITTED,
+                                   channel=mq_channel,
+                                   queue='%s-tmgr-to-sync' % sid,
+                                   profiler=local_prof,
+                                   logger=logger)
+
+        except KeyboardInterrupt as ex:
+            logger.error('Execution interrupted by user (you probably hit Ctrl+C), ' +
+                         'trying to cancel task processor gracefully...')
+
+        except Exception as ex:
             print traceback.format_exc()
             raise EnTKError(ex)
 
@@ -285,17 +328,17 @@ class TaskManager(Base_TaskManager):
                 self._tmgr_terminate = Event()
 
                 self._tmgr_process = Process(target=self._tmgr,
-                                            name='task-manager',
-                                            args=(
-                                                self._uid,
-                                                self._umgr,
-                                                self._rmgr,
-                                                self._logger,
-                                                self._mq_hostname,
-                                                self._port,
-                                                self._pending_queue,
-                                                self._completed_queue)
-                                            )
+                                             name='task-manager',
+                                             args=(
+                                                 self._uid,
+                                                 self._umgr,
+                                                 self._rmgr,
+                                                 self._logger,
+                                                 self._mq_hostname,
+                                                 self._port,
+                                                 self._pending_queue,
+                                                 self._completed_queue)
+                                             )
 
                 self._logger.info('Starting task manager process')
                 self._prof.prof('starting tmgr process', uid=self._uid)
@@ -310,5 +353,6 @@ class TaskManager(Base_TaskManager):
                 raise
 
         else:
-            self._logger.warn('tmgr process already running, but attempted to restart!')
+            self._logger.warn(
+                'tmgr process already running, but attempted to restart!')
     # ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes issue #270 and #285 . The duration taken to create and submit the CUs from tasks can become considerable when we have a large number of tasks. This duration interferes with the heartbeat interval of RMQ. In this PR we have moved these functions to a separate thread and making the thread where RMQ interactions exist to be non-blocking.