### PR TITLE
Fix/issue 303

### DIFF
--- a/docs/adv_examples/adapt_ta.rst
+++ b/docs/adv_examples/adapt_ta.rst
@@ -4,7 +4,7 @@
 Adaptive applications: Task-attribute
 *************************************
 
-We encourage you to take a look at the Pipeline of Ensembles example in the next page and compare with the above
+We encourage you to take a look at the Pipeline of Ensembles example on the next page and compare it with the above
 pattern.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.
@@ -17,8 +17,8 @@ or find it in your virtualenv under ``share/radical.entk/advanced_examples/scrip
 
 For any adaptive capability within a Pipeline, we need to use the post execution property of a Stage object. Decisions
 can only be performed once all tasks of a Stage are completed as the concurrent tasks cannot be interrupted by design.
-The post execution property of a Stage requires 3 function handles: a function that return a boolean, a function that is
-executed when boolean result is True, and a function that is executed when boolean result is False.
+The post execution property of a Stage requires 3 function handles: a function that returns a boolean, a function that is
+executed when the boolean result is True, and a function that is executed when the boolean result is False.
 
 .. code-block:: python
 
@@ -31,8 +31,8 @@ executed when boolean result is True, and a function that is executed when boole
 
 
 
-In the following example, we create 1 Pipeline with five stages. There are 10 tasks in each Stage that each run
-'sleep 30'. After a Stage is DONE (i.e. all tasks of the Stage have completed execution), a condition is evaluated
+In the following example, we create 1 Pipeline with five stages. There are 10 tasks in each Stage that each runs
+'sleep 30'. After a Stage is DONE (i.e. all tasks in the Stage have completed execution), a condition is evaluated
 that checks whether the current stage is less than the max number of stages in the Pipeline. If yes, then the arguments 
 of the tasks of the next Stage are modified. If not, no operation is performed.
 

--- a/docs/adv_examples/adapt_tc.rst
+++ b/docs/adv_examples/adapt_tc.rst
@@ -4,7 +4,7 @@
 Adaptive applications: Task-count
 *********************************
 
-We encourage you to take a look at the Pipeline of Ensembles example in the next page and compare with the above
+We encourage you to take a look at the Pipeline of Ensembles example on the next page and compare it with the above
 pattern.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.
@@ -17,8 +17,8 @@ find it in your virtualenv under ``share/radical.entk/advanced_examples/scripts`
 
 For any adaptive capability within a Pipeline, we need to use the post execution property of a Stage object. Decisions
 can only be performed once all tasks of a Stage are completed as the concurrent tasks cannot be interrupted by design.
-The post execution property of a Stage requires 3 function handles: a function that return a boolean, a function that is
-executed when boolean result is True, and a function that is executed when boolean result is False.
+The post execution property of a Stage requires 3 function handles: a function that returns a boolean, a function that is
+executed when the boolean result is True, and a function that is executed when the boolean result is False.
 
 .. code-block:: python
 
@@ -31,10 +31,10 @@ executed when boolean result is True, and a function that is executed when boole
 
 
 
-In the following example, we create 1 Pipeline with initially one Stage. There are 10 tasks in the first Stage that each
-run 'sleep 30'. After the Stage is DONE (i.e. all tasks of the Stage have completed execution), a condition is evaluated
-that checks whether number of new stages added is less than 4. If yes, we add a new Stage, with similar tasks as before,
-to the Pipeline. If 4 stages have already been added, no other stages are added.
+In the following example, we initially create 1 Pipeline with one Stage. There are 10 tasks in the first Stage that each
+runs 'sleep 30'. After the Stage is DONE (i.e. all tasks in the Stage have completed execution), a condition is evaluated
+that checks whether the number of new stages added is less than 4. If yes, we add a new Stage with similar tasks as before
+to the Pipeline. If 4 stages have already been added, no more stages are added.
 
 
 To run the script, simply execute the following from the command line:

--- a/docs/adv_examples/adapt_to.rst
+++ b/docs/adv_examples/adapt_to.rst
@@ -4,7 +4,7 @@
 Adaptive applications: Task-order
 *********************************
 
-We encourage you to take a look at the Pipeline of Ensembles example in the next page and compare with the above
+We encourage you to take a look at the Pipeline of Ensembles example on the next page and compare it with the above
 pattern.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.
@@ -17,8 +17,8 @@ find it in your virtualenv under ``share/radical.entk/advanced_examples/scripts`
 
 For any adaptive capability within a Pipeline, we need to use the post execution property of a Stage object. Decisions
 can only be performed once all tasks of a Stage are completed as the concurrent tasks cannot be interrupted by design.
-The post execution property of a Stage requires 3 function handles: a function that return a boolean, a function that is
-executed when boolean result is True, and a function that is executed when boolean result is False.
+The post execution property of a Stage requires 3 function handles: a function that returns a boolean, a function that is
+executed when the boolean result is True, and a function that is executed when the boolean result is False.
 
 .. code-block:: python
 

--- a/docs/entk.rst
+++ b/docs/entk.rst
@@ -12,7 +12,7 @@ elicit requirements and rapid prototyping
 Design
 ======
 
-We describe how applications modeled using EnTK components, the architecture
+We describe how applications are modeled using EnTK components, the architecture
 and execution model of EnTK. We also specify the types of failures recognized
 by EnTK and how some of the failures are handled.
 
@@ -43,14 +43,14 @@ In our PST model, we have the following objects:
 
 * **Task**: an abstraction of a computational task that contains information regarding an executable, its software environment and its data dependences.
 * **Stage**: a set of tasks without mutual dependences and that can be executed concurrently.
-* **Pipeline**: a list of stages where any stage i can be executed only after stage i−1 has been executed.
+* **Pipeline**: a list of stages where any stage 'i' can be executed only after stage 'i−1' has been executed.
 
-The entire application when assigned to the Application Manager can be expressed
-as a set of Pipelines. A graphical representation of an application is provided
-in Figure 1. Note how different Pipelines can have different number of Stages 
-and different Stages can have different number of Tasks.
+When assigned to the Application Manager, the entire application can be
+expressed as a set of Pipelines. A graphical representation of an application is provided
+in Figure 1. Note how different Pipelines can have different numbers of Stages, 
+and different Stages can have different numbers of Tasks.
 
-By expressing your application as a set or *list* of such Pipelines, one can 
+By expressing your application as a *set* or *list* of such Pipelines, one can 
 create any application that can be expressed as a DAG.
 
 
@@ -68,7 +68,7 @@ and execution management from the user.
  `Figure 2: Ensemble Toolkit Architecture and Execution Model`
 
 
-Fig. 2 shows the components (purple) and subcomponents (green) of EnTK, 
+Figure 2 shows the components (purple) and subcomponents (green) of EnTK, 
 organized in three layers: API, Workflow Management, and Workload Management.
 The API layer enables users to codify PST descriptions. The Workflow Management 
 layer retrieves information from the user about available CIs, initializes EnTK,
@@ -112,7 +112,7 @@ executables. All state updates in EnTK are transactional, hence any EnTK
 component that fails can be restarted at runtime without losing information
 about ongoing execution. Both the RTS and the CI are considered black boxes. 
 Partial failures of their subcomponents at runtime are assumed to be handled 
-locally. CI-level failures are reported to EnTK indirectly, either as a failed 
+locally. CI-level failures are reported to EnTK indirectly, either as failed 
 pilots or failed tasks. Both pilots and tasks can be restarted. Failures are 
 logged and reported to the user at runtime for live or postmortem analysis
 
@@ -124,7 +124,7 @@ EnTK is implemented in Python, uses RabbitMQ message queuing system and the
 RADICAL-Pilot (RP) runtime system. All EnTK components are implemented as 
 processes, and all subcomponents as threads.
 
-RabbitMQ is a server-based system and requires to be installed before the 
+RabbitMQ is a server-based system and is required to be installed before the 
 execution of EnTK. This adds overheads but it also offers the following 
 benefits: (1) producers and consumers do not need to be topology aware because 
 they interact only with the server; (2) messages are stored in the server and
@@ -152,7 +152,7 @@ Performance
 Below we present the weak and strong scaling behavior of EnTK on the ORNL
 Titan machine.
 
-Detailed description of the experiments can be found in 
+Detailed description of the experiments can be found in this 
 `technical paper <https://arxiv.org/pdf/1710.08491>`_.
 
 .. figure:: figures/entk_weak_scaling.png

--- a/docs/examples/eop.rst
+++ b/docs/examples/eop.rst
@@ -17,7 +17,7 @@ provided below.
    `Figure 1: Ensemble of Pipelines`
 
 
-We encourage you to take a look at the Pipeline of Ensembles example in the next page and compare with the above
+We encourage you to take a look at the Pipeline of Ensembles example on the next page and compare with the above
 pattern.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.
@@ -25,7 +25,7 @@ pattern.
 .. note:: This chapter assumes that you have successfully installed Ensemble Toolkit, if not see :ref:`Installation`.
 
 
-In the following example, we create 10 Pipelines each with three Stages. The Task in the first Stage creates a file. The
+In the following example, we create 10 Pipelines, each with three Stages. The Task in the first Stage creates a file. The
 Task in the second Stage performs a character count on that file. The Task in the third Stage performs
 a checksum on the output of the Task from the second stage.
 

--- a/docs/examples/eop.rst
+++ b/docs/examples/eop.rst
@@ -17,7 +17,7 @@ provided below.
    `Figure 1: Ensemble of Pipelines`
 
 
-We encourage you to take a look at the Pipeline of Ensembles example on the next page and compare with the above
+We encourage you to take a look at the Pipeline of Ensembles example on the next page and compare it with the above
 pattern.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.

--- a/docs/examples/poe.rst
+++ b/docs/examples/poe.rst
@@ -17,7 +17,7 @@ provided below.
    `Figure 1: Pipeline of Ensembles`
 
 
-We encourage you to take a look at the Ensemble of Pipelines example on the next page and compare with the above
+We encourage you to take a look at the Ensemble of Pipelines example on the next page and compare it with the above
 pattern.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.

--- a/docs/examples/poe.rst
+++ b/docs/examples/poe.rst
@@ -17,7 +17,7 @@ provided below.
    `Figure 1: Pipeline of Ensembles`
 
 
-We encourage you to take a look at the Ensemble of Pipelines example in the next page and compare with the above
+We encourage you to take a look at the Ensemble of Pipelines example on the next page and compare with the above
 pattern.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,7 +15,7 @@ To install the Ensemble Toolkit, we need to create a virtual environment. Open a
         source $HOME/myenv/bin/activate
 
 
-The suggested to use is the released version of EnTK which you can install
+It is suggested to use the released version of EnTK which you can install
 by executing the following command in your virtualenv:
 
 .. code-block:: bash
@@ -50,10 +50,10 @@ Installing rabbitmq
 Installing rabbitmq as a system process (sudo privileges required)
 ------------------------------------------------------------------
 
-Ensemble toolkit relies on RabbitMQ for message transfers. Installation
-instructions can be found at ```https://www.rabbitmq.com/download.html```. At
+Ensemble Toolkit relies on RabbitMQ for message transfers. Installation
+instructions can be found at <https://www.rabbitmq.com/download.html>. At
 the end of the installation run ```rabbitmq-server``` to start the server.
-RabbitMQ needs to be installed on the same machine as where EnTK is installed.
+RabbitMQ needs to be installed on the same machine as EnTK is installed.
 
 In some cases, you might have to explicitly start the rabbitmq-server after
 installation. You can check if the rabbitmq-server process is alive. If not,
@@ -131,7 +131,7 @@ a small VM instance (e.g., Amazon AWS) works exceptionally well for this.
 .. warning:: If you want to run your application on your laptop or private
             workstation, but run your MD tasks on a remote HPC cluster,
             installing MongoDB on your laptop or workstation won't work.
-            Your laptop or workstations usually does not have a public IP
+            Your laptop or workstation usually does not have a public IP
             address and is hidden behind a masked and firewalled home or office
             network. This means that the components running on the HPC cluster
             will not be able to access the MongoDB server.
@@ -152,7 +152,7 @@ http://docs.mongodb.org/manual/installation/
 **MongoDB-as-a-Service**
 
 There are multiple commercial providers of hosted MongoDB services, some of them
-offering free usage tiers. We have had some good experience with the following:
+offer free usage tiers. We have had some good experience with the following:
 
 * https://mongolab.com/
 
@@ -192,7 +192,7 @@ Setting up GSISSH access to a machine is a bit more complicated. We have documen
 trusty and xenial) and `Mac <https://github.com/vivek-bala/docs/blob/master/misc/gsissh_setup_mac>`_. Simply execute
 all the commands, see comments for details.
 
-The above links document the overall procedure and get certificates to access XSEDE machines. Depending on the machine
+The above links document the overall procedure and how to get certificates to access XSEDE machines. Depending on the machine
 you want to access, you will have to get the certificates from the corresponding locations. In most cases, this
 information is available in their user guide.
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -43,19 +43,19 @@ are used directly by the user. The **Pipeline**, **Stage** and **Task** are
 components used to create the application by describing its task graph. We will 
 soon take a look into how these can be used to create an application.
 
-The **Application Manager** is an internal components, that takes the workflow 
-described by the user and converts them into a set of **workloads**, i.e. tasks
+The **Application Manager** is an internal component, that takes a workflow 
+described by the user and converts it into a set of **workloads**, i.e. tasks
 with no dependencies by parsing through the workflow and identifying, during 
 runtime, tasks with equivalent or no dependencies. The Application Manager
 also accepts the description of the resource request (with resource
 label, walltime, cpus, gpus, user credentials) to be created.
 
 The **Execution Manager** is the last component in Ensemble Toolkit. It 
-accepts the workload prepared by the Application Manager and executes them on 
+accepts the workloads prepared by the Application Manager and executes them on 
 the specified resource using a Runtime system (RTS). Internally, it consists of 
 two subcomponents: ResourceManager and TaskManager, that are responsible for the
 allocation, management, and deallocation of resources, and execution management
-of tasks respectively. The Execution Manager is currently configured to use
+of tasks, respectively. The Execution Manager is currently configured to use
 `RADICAL Pilot (RP) <http://radicalpilot.readthedocs.org>`_ as the runtime 
 system, but can be extended to other RTS.
 
@@ -89,15 +89,15 @@ or directly plot the required fields.
 
 Dependencies such as RP and Pandas are automatically installed when installing 
 EnTK. RabbitMQ, on the other hand, needs to be installed manually by the user.
-Instructions for all are provided in :ref:`here <installation>`.
+Instructions are provided :ref:`here <installation>`.
 
 Five steps to create an application
 -----------------------------------
 
-1. Use the Pipeline, Stage and Task components to create the workflow
+1. Use the Pipeline, Stage and Task components to create the workflow.
 2. Create an Application Manager (Amgr) object with required parameters/configurations.
 3. Describe the resource request to be created. Assign resource request description and workflow to the Amgr.
-4. Run the Application Manager
+4. Run the Application Manager.
 5. Sit back and relax!
 
 Jump ahead to take a look at the step by step instructions for an example
@@ -106,14 +106,13 @@ script :ref:`here <uguide_get_started>`.
 Intended users
 ==============
 
-Ensemble Toolkit is completely python based and requires familiarity with the 
-python language. 
+Ensemble Toolkit is completely Python based and requires familiarity with the 
+Python language. 
 
 Our primary focus is to support domain scientists and enable them to execute 
-their applications at scale on various of CI. But this does not mean this 
-framework cannot be used by users with simpler requirements. Even if no HPC is 
-to be used, consider using EnTK for its automation and fault-tolerance 
-capabilities (even on your personal PC)!
+their applications at scale on various CIs. This, however, does not mean that this 
+framework cannot be used by users with simpler requirements. Consider using EnTK for
+its automation and fault-tolerance capabilities, even if it requires no HPC (even on your personal PC!).
 
 Some of our current users are mentioned below.
 

--- a/docs/user_guide/adding_data.rst
+++ b/docs/user_guide/adding_data.rst
@@ -17,7 +17,7 @@ move data between different tasks.
 You can download the complete code discussed in this section :download:`here <../../examples/user_guide/add_data.py>` or
 find it in your virtualenv under ``share/radical.entk/user_guide/scripts``.
 
-In the following example, we will create a Pipeline of two Stages each with one Task. In the first stage, we will
+In the following example, we will create a Pipeline of two Stages, each with one Task. In the first stage, we will
 create a file of size 1MB. In the next stage, we will perform a character count on the same file and write to another
 file. Finally, we will bring that output to the current location. 
 

--- a/docs/user_guide/adding_pipelines.rst
+++ b/docs/user_guide/adding_pipelines.rst
@@ -18,7 +18,7 @@ or find it in your virtualenv under ``share/radical.entk/user_guide/scripts``.
         
 
 Below, you can see the code snippet that shows how you can create a workflow with two Pipelines. You simple create more 
-another Pipeline objects, populate them with Stages and Tasks and create the workflow as a set of two Pipelines 
+Pipeline objects, populate them with Stages and Tasks and create the workflow as a set of two Pipelines 
 and assign them to the Application Manager. 
 
 .. literalinclude:: ../../examples/user_guide/add_pipelines.py

--- a/docs/user_guide/adding_shared_data.rst
+++ b/docs/user_guide/adding_shared_data.rst
@@ -18,9 +18,9 @@ a look at how we can move data shared between multiple tasks to the remote machi
 You can download the complete code discussed in this section :download:`here <../../examples/user_guide/add_shared_data.py>` 
 or find it in your virtualenv under ``share/radical.entk/user_guide/scripts``.
 
-In the following example, we will create a Pipeline with one Stage with 10 tasks. The tasks concatenate two input files 
+In the following example, we will create a Pipeline with one Stage and 10 tasks. The tasks concatenate two input files 
 and write the standard output to a file. Since the two input files are common between all the tasks, it will be efficient
-to be transfer those files only once to the remote machine and have the tasks copy the input files when being 
+to transfer those files only once to the remote machine and have the tasks copy the input files when being 
 executed. 
 
 Users can specify such shared data using the ``shared_data`` attribute of the AppManager object.
@@ -39,7 +39,7 @@ file movement description of the task.
     :lines: 25-30
     :dedent: 4
 
-In the example provided, the two files contain the words 'Hello' and 'World' respectively and the output files
+In the example provided, the two files contain the words 'Hello' and 'World', respectively, and the output files
 are expected to contain 'Hello World'
 
 To run the script, simply execute the following from the command line:

--- a/docs/user_guide/change_target.rst
+++ b/docs/user_guide/change_target.rst
@@ -9,9 +9,9 @@ All of our examples so far have been run locally. Its time to run something on
 a HPC! One of the features of Ensemble Toolkit is that you can submit tasks on 
 another machine remotely from your local machine. But this has some requirements, 
 you need to have passwordless ssh or gsissh access to the target machine. If you
-don't have such access, we discuss setup :ref:`here <ssh_gsissh_setup>`. You 
+don't have such access, we discuss the setup :ref:`here <ssh_gsissh_setup>`. You 
 also need to confirm that RP and Ensemble Toolkit are supported on this machine.
-A list of supported machines and mechanism to get support for new machines is 
+A list of supported machines and how to get support for new machines is 
 discussed :ref:`here <entk>`.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through 

--- a/docs/user_guide/get_started.rst
+++ b/docs/user_guide/get_started.rst
@@ -5,7 +5,7 @@
 Getting Started
 ***************
 
-In this section we will run you through Ensemble Toolkit  API.
+In this section we will run through the Ensemble Toolkit API.
 We will develop an example application consisting of a simple bag of Tasks.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.
@@ -48,17 +48,17 @@ In the below snippet, we first create a Pipeline then a Stage.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 13-17
+    :lines: 20-24
     :linenos:
-    :lineno-start: 13
+    :lineno-start: 20
 
 Next, we create a Task and assign its name, executable and arguments of the executable.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 19-23
+    :lines: 26-30
     :linenos:
-    :lineno-start: 19
+    :lineno-start: 26
 
 
 Now, that we have a fully described Task, a Stage and a Pipeline. We create our workflow by adding the Task to the
@@ -66,24 +66,24 @@ Stage and adding the Stage to the Pipeline.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 25-29
+    :lines: 32-36
     :linenos:
-    :lineno-start: 25
+    :lineno-start: 32
 
 
 Creating the AppManager 
 =======================
 
-Now that our workflow is created, we need to specify where the it needs to be executed. For this example, we will 
+Now that our workflow has been created, we need to specify where it is to be executed. For this example, we will 
 simply execute the workflow locally. We create an AppManager object, describe a resource request for 1 core for 10 
 minutes on localhost, i.e. your local machine. We assign the resource request description and the workflow to the
 AppManager and ``run`` our application.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 31-52
+    :lines: 38-59
     :linenos:
-    :lineno-start: 31
+    :lineno-start: 38
 
 
 
@@ -94,9 +94,9 @@ To run the script, simply execute the following from the command line:
     python get_started.py
 
 
-And that's it! That's all the steps of the example. Let's take a look at the complete code in the example. You can generate
-a more verbose output by setting the environment variable ``RADICAL_ENTK_VERBOSE=DEBUG``.
+And that's it! That's all the steps in this example. You can generate more verbose output
+by setting the environment variable ``RADICAL_ENTK_VERBOSE=DEBUG``.
 
-A look at the complete code in this section:
+Let's look at the complete code for this example:
 
 .. literalinclude:: ../../examples/user_guide/get_started.py


### PR DESCRIPTION
Collection of typo fixes in EnTK documentation. Most corrections are minor, some are more significant, e.g. the line corrections in `docs/user_guide/get_started.rst`.