### PR TITLE
Travis YML update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,18 @@ env:
     - OLD=`echo $LOG | cut -d ' ' -f2`
     - NEW=`echo $LOG | cut -d ' ' -f3`
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
+    - echo $DIFF
     - DIFF=$(echo "$DIFF" | sed -e 's/.flake8//g')
     - DIFF=$(echo "$DIFF" | sed -e 's/.pylintrc//g')
     - DIFF=$(echo "$DIFF" | sed -e 's/.coveragerc//g')
     - DIFF=$(echo "$DIFF" | sed -e 's/.travis.yml//g')
+    - echo $DIFF
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="if [[ $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD2="echo $DIFF; if [[ $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
     - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:
-    - MAIN_CMD=$CMD1 COVERAGE=true
+    #- MAIN_CMD=$CMD1 COVERAGE=true
     - MAIN_CMD=$CMD2
     - MAIN_CMD=$CMD3
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
     - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="echo $(LOG);echo $(DIFF); if [[ $(DIFF) ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD2="echo '"$LOG"';echo '"$DIFF"'; if [[ '"$DIFF"' ]]; then flake8 --config=.flake8 $DIFF; fi"
     - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,15 @@ env:
     - NEW=`echo $LOG | cut -d ' ' -f3`
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
     - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
-    - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="if [[ -z '\"\$DIFF\"' ]]; then flake8 --config=.flake8 $DIFF; fi"
-    - CMD3="if [[ -z '\"\$DIFF\"' ]]; then pylint $DIFF; fi"
+    - CMD_PYTEST="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
+    - CMD_FLAKE8="if [[ -z '\"\$DIFF\"' ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD_PYLINT="if [[ -z '\"\$DIFF\"' ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:
-    - MAIN_CMD=$CMD1 COVERAGE=true
-    - MAIN_CMD=$CMD2
-    - MAIN_CMD=$CMD3
+    - MAIN_CMD=$CMD_PYTEST COVERAGE=true
+    - MAIN_CMD=$CMD_FLAKE8
+    - MAIN_CMD=$CMD_PYLINT  
+  
   
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,21 @@ env:
     - OLD=`echo $LOG | cut -d ' ' -f2`
     - NEW=`echo $LOG | cut -d ' ' -f3`
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
+    - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
     - CMD2="flake8 --config=.flake8 $DIFF"
     - CMD3="pylint $DIFF"
     - COVERAGE=false
   matrix:
     - MAIN_CMD=$CMD1 COVERAGE=true
-    - MAIN_CMD=$CMD2
-    - MAIN_CMD=$CMD3
+    - |
+      if [[ $DIFF ]]; then \
+        MAIN_CMD=$CMD2
+      fi
+    - |
+      if [[ $DIFF ]]; then \
+        MAIN_CMD=$CMD3
+      fi
   
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
     - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="if [[ -z $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
-    - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
+    - CMD2="if [[ -z '"\$DIFF"' ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD3="if [[ -z '"\$DIFF"' ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:
     #- MAIN_CMD=$CMD1 COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,9 @@ env:
     - OLD=`echo $LOG | cut -d ' ' -f2`
     - NEW=`echo $LOG | cut -d ' ' -f3`
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
-    - DIFF=$(echo "$DIFF" | sed -e 's/.flake8//g')
-    - DIFF=$(echo "$DIFF" | sed -e 's/.pylintrc//g')
-    - DIFF=$(echo "$DIFF" | sed -e 's/.coveragerc//g')
-    - DIFF=$(echo "$DIFF" | sed -e 's/.travis.yml//g')
+    - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="echo '${LOG}';echo '${DIFF}'; if [[ '${DIFF}' ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD2="echo $(LOG);echo $(DIFF); if [[ $(DIFF) ]]; then flake8 --config=.flake8 $DIFF; fi"
     - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,18 @@ env:
     - OLD=`echo $LOG | cut -d ' ' -f2`
     - NEW=`echo $LOG | cut -d ' ' -f3`
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
-    - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
+    - DIFF=$(echo "$DIFF" | sed -e 's/.flake8//g')
+    - DIFF=$(echo "$DIFF" | sed -e 's/.pylintrc//g')
+    - DIFF=$(echo "$DIFF" | sed -e 's/.coveragerc//g')
+    - DIFF=$(echo "$DIFF" | sed -e 's/.travis.yml//g')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="flake8 --config=.flake8 $DIFF"
-    - CMD3="pylint $DIFF"
+    - CMD2="if [[ $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:
     - MAIN_CMD=$CMD1 COVERAGE=true
-    - |
-      if [[ $DIFF ]]; then \
-        MAIN_CMD=$CMD2
-      fi
-    - |
-      if [[ $DIFF ]]; then \
-        MAIN_CMD=$CMD3
-      fi
+    - MAIN_CMD=$CMD2
+    - MAIN_CMD=$CMD3
   
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - CMD3="if [[ -z '\"\$DIFF\"' ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:
-    #- MAIN_CMD=$CMD1 COVERAGE=true
+    - MAIN_CMD=$CMD1 COVERAGE=true
     - MAIN_CMD=$CMD2
     - MAIN_CMD=$CMD3
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - DIFF=$(echo "$DIFF" | sed -e 's/.coveragerc//g')
     - DIFF=$(echo "$DIFF" | sed -e 's/.travis.yml//g')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="echo $LOG;echo $DIFF; if [[ $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD2="echo '${LOG}';echo '${DIFF}'; if [[ '${DIFF}' ]]; then flake8 --config=.flake8 $DIFF; fi"
     - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,12 @@ env:
     - OLD=`echo $LOG | cut -d ' ' -f2`
     - NEW=`echo $LOG | cut -d ' ' -f3`
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
-    - echo $DIFF
     - DIFF=$(echo "$DIFF" | sed -e 's/.flake8//g')
     - DIFF=$(echo "$DIFF" | sed -e 's/.pylintrc//g')
     - DIFF=$(echo "$DIFF" | sed -e 's/.coveragerc//g')
     - DIFF=$(echo "$DIFF" | sed -e 's/.travis.yml//g')
-    - echo $DIFF
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="echo $DIFF; if [[ $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD2="echo $LOG;echo $DIFF; if [[ $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
     - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
     - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="if [[ -z '"\$DIFF"' ]]; then flake8 --config=.flake8 $DIFF; fi"
-    - CMD3="if [[ -z '"\$DIFF"' ]]; then pylint $DIFF; fi"
+    - CMD2="if [[ -z '\"\$DIFF\"' ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD3="if [[ -z '\"\$DIFF\"' ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:
     #- MAIN_CMD=$CMD1 COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
     - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
     - CMD1="coverage run -m pytest -vvv tests/test_component/test_amgr.py;coverage run -m pytest -vvv tests/test_component/test_modules.py;coverage run -m pytest -vvv tests/test_component/test_pipeline.py;coverage run -m pytest -vvv tests/test_component/test_rmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_rmgr.py;coverage run -m pytest -vvv tests/test_component/test_stage.py;coverage run -m pytest -vvv tests/test_component/test_task.py;coverage run -m pytest -vvv tests/test_component/test_tmgr_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp_2.py;coverage run -m pytest -vvv tests/test_component/test_tproc_rp.py;coverage run -m pytest -vvv tests/test_component/test_tmgr.py;coverage run -m pytest -vvv tests/test_component/test_wfp.py;coverage run -m pytest -vvv tests/test_component/test_states.py;coverage run -m pytest -vvv tests/test_integration/test_*;coverage run -m pytest -vvv tests/test_issues/test_*;coverage run -m pytest -vvv tests/test_utils/test_*"
-    - CMD2="echo '"$LOG"';echo '"$DIFF"'; if [[ '"$DIFF"' ]]; then flake8 --config=.flake8 $DIFF; fi"
+    - CMD2="if [[ -z $DIFF ]]; then flake8 --config=.flake8 $DIFF; fi"
     - CMD3="if [[ $DIFF ]]; then pylint $DIFF; fi"
     - COVERAGE=false
   matrix:


### PR DESCRIPTION
Travis YML file is updated to include only `py` files for flak8 and pylint and also tries to disable them if there is no diff in a `py` file.

This is done on whether `$DIFF` is empty or not. We should not do this on `$LOG` because `$LOG` can be non empty if we change a non python file as in this PR.