### PR TITLE
attempt to fix wfp creation

### DIFF
--- a/tests/test_issues/test_issue_26.py
+++ b/tests/test_issues/test_issue_26.py
@@ -44,12 +44,10 @@ def test_issue_26():
     p1 = create_pipeline()
     appman.workflow = [p1]
     appman.run()
-    print '====', p1.uid, p1.stages[0].uid
 
     p2 = create_pipeline()
     appman.workflow = [p2]
     appman.run()
-    print '====', p2.uid, p2.stages[0].uid
 
     appman.resource_terminate()
 

--- a/tests/test_issues/test_issue_26.py
+++ b/tests/test_issues/test_issue_26.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import radical.utils as ru
+
 from radical.entk import Pipeline, Stage, Task, AppManager
 from radical.entk import states
 from radical.entk.exceptions import *
@@ -42,12 +44,12 @@ def test_issue_26():
     p1 = create_pipeline()
     appman.workflow = [p1]
     appman.run()
-    print p1.uid, p1.stages[0].uid
+    print '====', p1.uid, p1.stages[0].uid
 
     p2 = create_pipeline()
     appman.workflow = [p2]
     appman.run()
-    print p2.uid, p2.stages[0].uid
+    print '====', p2.uid, p2.stages[0].uid
 
     appman.resource_terminate()
 
@@ -55,10 +57,10 @@ def test_issue_26():
     rhs = int(p2.stages[0].uid.split('.')[-1])
     assert lhs == rhs
 
-    for t1 in p1.stages[0].tasks:
-        for t2 in p2.stages[0].tasks:
-            lhs = int(t1.uid.split('.')[-1]) + 1
-            rhs = int(t2.uid.split('.')[-1])
+    for t in p1.stages[0].tasks:
+        for tt in p2.stages[0].tasks:
+            lhs = int(t.uid.split('.')[-1]) + 1
+            rhs = int(tt.uid.split('.')[-1])
             assert lhs == rhs
 
 


### PR DESCRIPTION
This is an attempt to fix the WFP creation, and ensure it is only created once.  

Test issue_26 now terminates, but still fails because of some uid issues which I assume are unrelated (but I don't know).  Anyway, @vivek-bala , please have a look at this PR if that makes any sense.

The apparently WFP can't be started in `__init__` because, well, reasons: at that point no resource is assigned which means that no resource manager exists which means that the task manager cannot be created.  I think those instantiations need to be disentangled - the WFP should have nothing to do with the task manager, it can begin working even if there is no task manager or resource listening on the other end of the queue?