### PR TITLE
battle test resource issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - NEW=`echo $LOG | cut -d ' ' -f3`
     - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
     - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
-    - PYTEST="coverage run -m pytest -ra --timeout=600 -vvv --showlocals"
+    - PYTEST="coverage run -m pytest -ra --timeout=600 -vvv --showlocals --forked --numprocesses=3"
     - CMD_PYTEST_UNITTESTS="  $PYTEST tests/test_component/  ;
                               $PYTEST tests/test_utils/      "
     - CMD_PYTEST_INTEGRATION="$PYTEST tests/test_integration/"
@@ -51,6 +51,7 @@ install:
   - pip install pylint
   - pip install codecov
   - pip install pytest
+  - pip install pytest-xdist
   - pip install pytest-timeout
 
 before_script:

--- a/src/radical/entk/execman/rp/__init__.py
+++ b/src/radical/entk/execman/rp/__init__.py
@@ -1,2 +1,4 @@
+
 from resource_manager import ResourceManager
-from task_manager import TaskManager
+from task_manager     import TaskManager
+

--- a/src/radical/entk/execman/rp/resource_manager.py
+++ b/src/radical/entk/execman/rp/resource_manager.py
@@ -61,6 +61,21 @@ class ResourceManager(Base_ResourceManager):
 
     # --------------------------------------------------------------------------
     #
+    def __del__(self):
+        '''
+        RE must release the session to avoid leaking threads
+        '''
+
+        try:
+            if self._session:
+                self._session.close()
+                self._session = None
+        except:
+            pass
+
+
+    # --------------------------------------------------------------------------
+    #
     @property
     def session(self):
         """
@@ -179,6 +194,7 @@ class ResourceManager(Base_ResourceManager):
 
             if self._session:
                 self._session.close()
+                self._session = None
 
             self._logger.exception('Execution interrupted (probably by Ctrl+C) '
                                    'exit callback thread gracefully...')
@@ -207,6 +223,7 @@ class ResourceManager(Base_ResourceManager):
                 cleanup      = self._rts_config.get('db_cleanup', False)
 
                 self._session.close(cleanup=cleanup, download=get_profiles)
+                self._session = None
                 self._prof.prof('rreq_canceled', uid=self._uid)
 
         except KeyboardInterrupt:

--- a/tests/test_integration/test_tproc_rp.py
+++ b/tests/test_integration/test_tproc_rp.py
@@ -289,25 +289,24 @@ def test_create_task_from_cu():
                  a RP ComputeUnit.
     """
 
-    session        = rp.Session()
-    umgr           = rp.UnitManager(session=session)
-    cud            = rp.ComputeUnitDescription()
-    cud.name       = 'uid, name, parent_stage_uid, parent_stage_name, ' \
-                     'parent_pipeline_uid, parent_pipeline_name'
-    cud.executable = '/bin/echo'
+    with rp.Session() as session:
 
-    cu = rp.ComputeUnit(umgr, cud)
+        umgr           = rp.UnitManager(session=session)
+        cud            = rp.ComputeUnitDescription()
+        cud.name       = 'uid, name, parent_stage_uid, parent_stage_name, ' \
+                         'parent_pipeline_uid, parent_pipeline_name'
+        cud.executable = '/bin/echo'
 
-    t = create_task_from_cu(cu)
+        cu = rp.ComputeUnit(umgr, cud)
 
-    assert t.uid                     == 'uid'
-    assert t.name                    == 'name'
-    assert t.parent_stage['uid']     == 'parent_stage_uid'
-    assert t.parent_stage['name']    == 'parent_stage_name'
-    assert t.parent_pipeline['uid']  == 'parent_pipeline_uid'
-    assert t.parent_pipeline['name'] == 'parent_pipeline_name'
+        t = create_task_from_cu(cu)
 
-    session.close()
+        assert t.uid                     == 'uid'
+        assert t.name                    == 'name'
+        assert t.parent_stage['uid']     == 'parent_stage_uid'
+        assert t.parent_stage['name']    == 'parent_stage_name'
+        assert t.parent_pipeline['uid']  == 'parent_pipeline_uid'
+        assert t.parent_pipeline['name'] == 'parent_pipeline_name'
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_integration/test_tproc_rp_2.py
+++ b/tests/test_integration/test_tproc_rp_2.py
@@ -17,24 +17,23 @@ def test_create_task_from_cu():
     parent_pipeline from a RP ComputeUnit
     """
 
-    session        = rp.Session()
-    umgr           = rp.UnitManager(session=session)
-    cud            = rp.ComputeUnitDescription()
-    cud.name       = 'uid, name, parent_stage_uid, parent_stage_name, ' \
-                     'parent_pipeline_uid, parent_pipeline_name'
-    cud.executable = '/bin/echo'
+    with rp.Session() as session:
 
-    cu = rp.ComputeUnit(umgr, cud)
-    t  = create_task_from_cu(cu)
+        umgr           = rp.UnitManager(session=session)
+        cud            = rp.ComputeUnitDescription()
+        cud.name       = 'uid, name, parent_stage_uid, parent_stage_name, ' \
+                         'parent_pipeline_uid, parent_pipeline_name'
+        cud.executable = '/bin/echo'
 
-    assert t.uid                     == 'uid'
-    assert t.name                    == 'name'
-    assert t.parent_stage['uid']     == 'parent_stage_uid'
-    assert t.parent_stage['name']    == 'parent_stage_name'
-    assert t.parent_pipeline['uid']  == 'parent_pipeline_uid'
-    assert t.parent_pipeline['name'] == 'parent_pipeline_name'
+        cu = rp.ComputeUnit(umgr, cud)
+        t  = create_task_from_cu(cu)
 
-    session.close()
+        assert t.uid                     == 'uid'
+        assert t.name                    == 'name'
+        assert t.parent_stage['uid']     == 'parent_stage_uid'
+        assert t.parent_stage['name']    == 'parent_stage_name'
+        assert t.parent_pipeline['uid']  == 'parent_pipeline_uid'
+        assert t.parent_pipeline['name'] == 'parent_pipeline_name'
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Run some tests in different processes to reduce resource consumption per process.  This specifically gets the integration tests going again, but also speeds up overall runtime.