### PR TITLE
Replaced RabbitMQ hostname,port with URL

### DIFF
--- a/src/radical/entk/appman/config.json
+++ b/src/radical/entk/appman/config.json
@@ -1,7 +1,5 @@
 
 {
-    "hostname"        : "localhost",
-    "port"            : 5672,
     "reattempts"      : 3,
     "resubmit_failed" : false,
     "autoterminate"   : true,
@@ -11,6 +9,7 @@
                          "db_cleanup"      : false },
     "pending_qs"      : 1,
     "completed_qs"    : 1,
-    "rmq_cleanup"     : true
+    "rmq_cleanup"     : true,
+    "rmq_url"         : "amqp://guest:guest@localhost:5672/%2F"
 }
 

--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -32,9 +32,8 @@ class WFprocessor(object):
         :workflow:        (set) REFERENCE of the AppManager's workflow
         :pending_queue:   (list) queues to hold pending tasks
         :completed_queue: (list) queues to hold completed tasks
-        :mq_hostname:     (str) hostname where the RabbitMQ is alive
-        :port:            (int) port at which RabbitMQ can be accessed
         :resubmit_failed: (bool) True if failed tasks should be resubmitted
+        :rmq_url          (str) URI connection string for RabbitMQ
     """
 
     # --------------------------------------------------------------------------
@@ -44,17 +43,15 @@ class WFprocessor(object):
                  workflow,
                  pending_queue,
                  completed_queue,
-                 mq_hostname,
-                 port,
-                 resubmit_failed):
+                 resubmit_failed,
+                 rmq_url):
 
         # Mandatory arguments
         self._sid             = sid
         self._pending_queue   = pending_queue
         self._completed_queue = completed_queue
-        self._hostname        = mq_hostname
-        self._port            = port
         self._resubmit_failed = resubmit_failed
+        self._rmq_url         = rmq_url
 
         # Assign validated workflow
         self._workflow = workflow
@@ -201,9 +198,7 @@ class WFprocessor(object):
 
         # Acquire a connection+channel to the rmq server
         mq_connection = pika.BlockingConnection(
-                            pika.ConnectionParameters(
-                                host=self._hostname,
-                                port=self._port))
+                            pika.URLParameters(self._rmq_url))
         mq_channel = mq_connection.channel()
 
         # Send the workload to the pending queue
@@ -409,9 +404,7 @@ class WFprocessor(object):
 
             # Acquire a connection+channel to the rmq server
             mq_connection = pika.BlockingConnection(
-                                pika.ConnectionParameters(
-                                    host=self._hostname,
-                                    port=self._port))
+                                pika.URLParameters(self._rmq_url))
             mq_channel = mq_connection.channel()
 
             last = time.time()

--- a/src/radical/entk/execman/mock/task_manager.py
+++ b/src/radical/entk/execman/mock/task_manager.py
@@ -33,8 +33,7 @@ class TaskManager(Base_TaskManager):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :mq_hostname:       (str) Name of the host where RabbitMQ is running
-        :port:              (int) Port at which rabbitMQ can be accessed
+        :rmq_url:           (str) URI connection string for RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one
     completed queue. In the future, the number of queues can be varied for
@@ -44,11 +43,10 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, sid, pending_queue, completed_queue, rmgr, mq_hostname,
-                       port):
+    def __init__(self, sid, pending_queue, completed_queue, rmgr, rmq_url):
 
         super(TaskManager, self).__init__(sid, pending_queue, completed_queue,
-                                          rmgr, mq_hostname, port, rts='mock')
+                                          rmgr, rts='mock', rmq_url)
         self._rts_runner = None
 
         self._rmq_ping_interval = os.getenv('RMQ_PING_INTERVAL', 10)
@@ -59,8 +57,7 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _tmgr(self, uid, rmgr, mq_hostname, port, pending_queue,
-                    completed_queue):
+    def _tmgr(self, uid, rmgr, pending_queue, completed_queue, rmq_url):
         """
         **Purpose**: Method to be run by the tmgr process. This method receives
                      a Task from the pending_queue and submits it to the RTS.
@@ -122,7 +119,7 @@ class TaskManager(Base_TaskManager):
 
             # Acquire a connection+channel to the rmq server
             mq_connection = pika.BlockingConnection(
-                pika.ConnectionParameters(host=mq_hostname, port=port))
+                pika.URLParameters(rmq_url))
             mq_channel = mq_connection.channel()
 
             # Make sure the heartbeat response queue is empty
@@ -134,8 +131,7 @@ class TaskManager(Base_TaskManager):
 
             # Start second thread to receive tasks and push to RTS
             self._rts_runner = mt.Thread(target=self._process_tasks,
-                                         args=(task_queue, rmgr, mq_hostname,
-                                               port))
+                                         args=(task_queue, rmgr, rmq_url))
             self._rts_runner.start()
 
             self._prof.prof('tmgr infrastructure setup done', uid=uid)
@@ -188,7 +184,7 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _process_tasks(self, task_queue, rmgr, mq_hostname, port):
+    def _process_tasks(self, task_queue, rmgr, rmq_url):
         '''
         **Purpose**: The new thread that gets spawned by the main tmgr process
                      invokes this function. This function receives tasks from
@@ -214,8 +210,7 @@ class TaskManager(Base_TaskManager):
                     task.name)] = str(task.path)
         # ----------------------------------------------------------------------
 
-        mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                   host=mq_hostname, port=port))
+        mq_connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
         mq_channel = mq_connection.channel()
 
         try:
@@ -295,10 +290,9 @@ class TaskManager(Base_TaskManager):
                                             name='task-manager',
                                             args=(self._uid,
                                                   self._rmgr,
-                                                  self._hostname,
-                                                  self._port,
                                                   self._pending_queue,
-                                                  self._completed_queue)
+                                                  self._completed_queue,
+                                                  self._rmq_url)
                                             )
 
             self._log.info('Starting task manager process')


### PR DESCRIPTION
I changed the interfaces not to use hostname and port for RabbitMQ but instead to use a connection string URL. This will break other programs that used to specify hostname and port. Those programs should still be able to run if they use a connection string that explicitly writes out the assumed default parameters, along the lines of "amqp://guest:guest@localhost:5672/%2F" (but I haven't tested that, either).