### PR TITLE
Accept username/password credentials for RabbitMQ

### DIFF
--- a/src/radical/entk/appman/config.json
+++ b/src/radical/entk/appman/config.json
@@ -1,5 +1,7 @@
 
 {
+    "hostname"        : "localhost",
+    "port"            : 5672,
     "reattempts"      : 3,
     "resubmit_failed" : false,
     "autoterminate"   : true,
@@ -9,7 +11,6 @@
                          "db_cleanup"      : false },
     "pending_qs"      : 1,
     "completed_qs"    : 1,
-    "rmq_cleanup"     : true,
-    "rmq_url"         : "amqp://guest:guest@localhost:5672/%2F"
+    "rmq_cleanup"     : true
 }
 

--- a/src/radical/entk/appman/config.json
+++ b/src/radical/entk/appman/config.json
@@ -10,6 +10,9 @@
     "pending_qs"      : 1,
     "completed_qs"    : 1,
     "rmq_cleanup"     : true,
-    "rmq_url"         : "amqp://guest:guest@localhost:5672/%2F"
+    "hostname"        : "localhost",
+    "port"            : 5672,
+    "username"        : "guest",
+    "password"        : "guest"
 }
 

--- a/src/radical/entk/appman/config.json
+++ b/src/radical/entk/appman/config.json
@@ -1,5 +1,9 @@
 
 {
+    "hostname"        : "localhost",
+    "port"            : 5672,
+    "username"        : "guest",
+    "password"        : "guest",
     "reattempts"      : 3,
     "resubmit_failed" : false,
     "autoterminate"   : true,
@@ -9,10 +13,6 @@
                          "db_cleanup"      : false },
     "pending_qs"      : 1,
     "completed_qs"    : 1,
-    "rmq_cleanup"     : true,
-    "hostname"        : "localhost",
-    "port"            : 5672,
-    "username"        : "guest",
-    "password"        : "guest"
+    "rmq_cleanup"     : true
 }
 

--- a/src/radical/entk/appman/config.json
+++ b/src/radical/entk/appman/config.json
@@ -1,7 +1,5 @@
 
 {
-    "hostname"        : "localhost",
-    "port"            : 5672,
     "reattempts"      : 3,
     "resubmit_failed" : false,
     "autoterminate"   : true,
@@ -11,6 +9,7 @@
                          "db_cleanup"      : false },
     "pending_qs"      : 1,
     "completed_qs"    : 1,
-    "rmq_cleanup"     : true
+    "rmq_cleanup"     : true,
+    "rmq_url"         : "amqp://guest:guest@localhost:5672/%2F"
 }
 

--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -32,9 +32,8 @@ class WFprocessor(object):
         :workflow:        (set) REFERENCE of the AppManager's workflow
         :pending_queue:   (list) queues to hold pending tasks
         :completed_queue: (list) queues to hold completed tasks
-        :mq_hostname:     (str) hostname where the RabbitMQ is alive
-        :port:            (int) port at which RabbitMQ can be accessed
         :resubmit_failed: (bool) True if failed tasks should be resubmitted
+        :rmq_url          (str) URI connection string for RabbitMQ
     """
 
     # --------------------------------------------------------------------------
@@ -44,17 +43,15 @@ class WFprocessor(object):
                  workflow,
                  pending_queue,
                  completed_queue,
-                 mq_hostname,
-                 port,
-                 resubmit_failed):
+                 resubmit_failed,
+                 rmq_url):
 
         # Mandatory arguments
         self._sid             = sid
         self._pending_queue   = pending_queue
         self._completed_queue = completed_queue
-        self._hostname        = mq_hostname
-        self._port            = port
         self._resubmit_failed = resubmit_failed
+        self._rmq_url         = rmq_url
 
         # Assign validated workflow
         self._workflow = workflow
@@ -201,9 +198,7 @@ class WFprocessor(object):
 
         # Acquire a connection+channel to the rmq server
         mq_connection = pika.BlockingConnection(
-                            pika.ConnectionParameters(
-                                host=self._hostname,
-                                port=self._port))
+                            pika.URLParameters(self._rmq_url))
         mq_channel = mq_connection.channel()
 
         # Send the workload to the pending queue
@@ -409,9 +404,7 @@ class WFprocessor(object):
 
             # Acquire a connection+channel to the rmq server
             mq_connection = pika.BlockingConnection(
-                                pika.ConnectionParameters(
-                                    host=self._hostname,
-                                    port=self._port))
+                                pika.URLParameters(self._rmq_url))
             mq_channel = mq_connection.channel()
 
             last = time.time()

--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -32,9 +32,9 @@ class WFprocessor(object):
         :workflow:        (set) REFERENCE of the AppManager's workflow
         :pending_queue:   (list) queues to hold pending tasks
         :completed_queue: (list) queues to hold completed tasks
-        :mq_hostname:     (str) hostname where the RabbitMQ is alive
-        :port:            (int) port at which RabbitMQ can be accessed
         :resubmit_failed: (bool) True if failed tasks should be resubmitted
+        :rmq_conn_params: (pika.connection.URLParameters) object of parameters
+                          necessary to connect to RabbitMQ
     """
 
     # --------------------------------------------------------------------------
@@ -44,17 +44,15 @@ class WFprocessor(object):
                  workflow,
                  pending_queue,
                  completed_queue,
-                 mq_hostname,
-                 port,
-                 resubmit_failed):
+                 resubmit_failed,
+                 rmq_conn_params):
 
         # Mandatory arguments
         self._sid             = sid
         self._pending_queue   = pending_queue
         self._completed_queue = completed_queue
-        self._hostname        = mq_hostname
-        self._port            = port
         self._resubmit_failed = resubmit_failed
+        self._rmq_conn_params = rmq_conn_params
 
         # Assign validated workflow
         self._workflow = workflow
@@ -200,10 +198,7 @@ class WFprocessor(object):
         wl_json = json.dumps([task.to_dict() for task in workload])
 
         # Acquire a connection+channel to the rmq server
-        mq_connection = pika.BlockingConnection(
-                            pika.ConnectionParameters(
-                                host=self._hostname,
-                                port=self._port))
+        mq_connection = pika.BlockingConnection(self._rmq_conn_params)
         mq_channel = mq_connection.channel()
 
         # Send the workload to the pending queue
@@ -435,10 +430,7 @@ class WFprocessor(object):
             self._logger.info('Dequeue thread started')
 
             # Acquire a connection+channel to the rmq server
-            mq_connection = pika.BlockingConnection(
-                                pika.ConnectionParameters(
-                                    host=self._hostname,
-                                    port=self._port))
+            mq_connection = pika.BlockingConnection(self._rmq_conn_params)
             mq_channel = mq_connection.channel()
 
             last = time.time()

--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -32,8 +32,9 @@ class WFprocessor(object):
         :workflow:        (set) REFERENCE of the AppManager's workflow
         :pending_queue:   (list) queues to hold pending tasks
         :completed_queue: (list) queues to hold completed tasks
+        :mq_hostname:     (str) hostname where the RabbitMQ is alive
+        :port:            (int) port at which RabbitMQ can be accessed
         :resubmit_failed: (bool) True if failed tasks should be resubmitted
-        :rmq_url          (str) URI connection string for RabbitMQ
     """
 
     # --------------------------------------------------------------------------
@@ -43,15 +44,17 @@ class WFprocessor(object):
                  workflow,
                  pending_queue,
                  completed_queue,
-                 resubmit_failed,
-                 rmq_url):
+                 mq_hostname,
+                 port,
+                 resubmit_failed):
 
         # Mandatory arguments
         self._sid             = sid
         self._pending_queue   = pending_queue
         self._completed_queue = completed_queue
+        self._hostname        = mq_hostname
+        self._port            = port
         self._resubmit_failed = resubmit_failed
-        self._rmq_url         = rmq_url
 
         # Assign validated workflow
         self._workflow = workflow
@@ -198,7 +201,9 @@ class WFprocessor(object):
 
         # Acquire a connection+channel to the rmq server
         mq_connection = pika.BlockingConnection(
-                            pika.URLParameters(self._rmq_url))
+                            pika.ConnectionParameters(
+                                host=self._hostname,
+                                port=self._port))
         mq_channel = mq_connection.channel()
 
         # Send the workload to the pending queue
@@ -404,7 +409,9 @@ class WFprocessor(object):
 
             # Acquire a connection+channel to the rmq server
             mq_connection = pika.BlockingConnection(
-                                pika.URLParameters(self._rmq_url))
+                                pika.ConnectionParameters(
+                                    host=self._hostname,
+                                    port=self._port))
             mq_channel = mq_connection.channel()
 
             last = time.time()

--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -33,8 +33,8 @@ class WFprocessor(object):
         :pending_queue:   (list) queues to hold pending tasks
         :completed_queue: (list) queues to hold completed tasks
         :resubmit_failed: (bool) True if failed tasks should be resubmitted
-        :rmq_conn_params: (pika.connection.URLParameters) object of parameters
-                          necessary to connect to RabbitMQ
+        :rmq_conn_params: (pika.connection.ConnectionParameters) object of
+                          parameters necessary to connect to RabbitMQ
     """
 
     # --------------------------------------------------------------------------

--- a/src/radical/entk/execman/base/task_manager.py
+++ b/src/radical/entk/execman/base/task_manager.py
@@ -33,8 +33,8 @@ class Base_TaskManager(object):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :mq_hostname:       (str) Name of the host where RabbitMQ is running
-        :port:              (int) Port at which rabbitMQ can be accessed
+        :rmq_conn_params:   (pika.connection.URLParameters) object of
+                            parameters necessary to connect to RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one
     completed queue. In the future, the number of queues can be varied for
@@ -44,8 +44,8 @@ class Base_TaskManager(object):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, sid, pending_queue, completed_queue, rmgr, mq_hostname,
-                       port, rts):
+    def __init__(self, sid, pending_queue, completed_queue, rmgr,
+                       rmq_conn_params, rts):
 
         if not isinstance(sid, basestring):
             raise TypeError(expected_type=basestring,
@@ -59,26 +59,20 @@ class Base_TaskManager(object):
             raise TypeError(expected_type=basestring,
                             actual_type=type(completed_queue))
 
-        if not isinstance(mq_hostname, basestring):
-            raise TypeError(expected_type=basestring,
-                            actual_type=type(mq_hostname))
-
-        if not isinstance(port, int):
-            raise TypeError(expected_type=int,
-                            actual_type=type(port))
-
         if not isinstance(rmgr, Base_ResourceManager):
             raise TypeError(expected_type=Base_ResourceManager,
                             actual_type=type(rmgr))
 
+        if not isinstance(rmq_conn_params, pika.connection.URLParameters):
+            raise TypeError(expected_type=pika.connection.URLParameters,
+                            actual_type=type(rmq_conn_params))
 
         self._sid             = sid
         self._pending_queue   = pending_queue
         self._completed_queue = completed_queue
-        self._hostname        = mq_hostname
-        self._port            = port
         self._rmgr            = rmgr
         self._rts             = rts
+        self._rmq_conn_params = rmq_conn_params
 
         # Utility parameters
         self._uid  = ru.generate_id('task_manager.%(item_counter)04d',
@@ -90,8 +84,7 @@ class Base_TaskManager(object):
         self._prof = ru.Profiler(name, path=self._path)
 
         # Thread should run till terminate condtion is encountered
-        mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                   host=mq_hostname, port=port))
+        mq_connection = pika.BlockingConnection(rmq_conn_params)
 
         self._hb_request_q  = '%s-hb-request'  % self._sid
         self._hb_response_q = '%s-hb-response' % self._sid
@@ -115,8 +108,8 @@ class Base_TaskManager(object):
 
     # --------------------------------------------------------------------------
     #
-    def _tmgr(self, uid, rmgr, mq_hostname, port, pending_queue,
-                    completed_queue):
+    def _tmgr(self, uid, rmgr, pending_queue, completed_queue,
+                    rmq_conn_params):
         """
         **Purpose**: Method to be run by the tmgr process. This method receives
                      a Task from the pending_queue and submits it to the RTS.
@@ -231,8 +224,7 @@ class Base_TaskManager(object):
 
             self._prof.prof('hbeat_start', uid=self._uid)
 
-            mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                       host=self._hostname, port=self._port))
+            mq_connection = pika.BlockingConnection(self._rmq_conn_params)
             mq_channel = mq_connection.channel()
 
             while not self._hb_terminate.is_set():
@@ -370,8 +362,7 @@ class Base_TaskManager(object):
 
             if not self.check_heartbeat() or self.check_manager():
 
-                conn = pika.BlockingConnection(pika.ConnectionParameters(
-                                       host=self._hostname, port=self._port))
+                conn = pika.BlockingConnection(self._rmq_conn_params)
                 mq_channel = conn.channel()
 
                 # To respond to heartbeat - get request from rpc_queue

--- a/src/radical/entk/execman/base/task_manager.py
+++ b/src/radical/entk/execman/base/task_manager.py
@@ -33,7 +33,7 @@ class Base_TaskManager(object):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :rmq_conn_params:   (pika.connection.URLParameters) object of
+        :rmq_conn_params:   (pika.connection.ConnectionParameters) object of
                             parameters necessary to connect to RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one
@@ -63,8 +63,9 @@ class Base_TaskManager(object):
             raise TypeError(expected_type=Base_ResourceManager,
                             actual_type=type(rmgr))
 
-        if not isinstance(rmq_conn_params, pika.connection.URLParameters):
-            raise TypeError(expected_type=pika.connection.URLParameters,
+        if not isinstance(rmq_conn_params,
+                            pika.connection.ConnectionParameters):
+            raise TypeError(expected_type=pika.connection.ConnectionParameters,
                             actual_type=type(rmq_conn_params))
 
         self._sid             = sid

--- a/src/radical/entk/execman/base/task_manager.py
+++ b/src/radical/entk/execman/base/task_manager.py
@@ -33,7 +33,8 @@ class Base_TaskManager(object):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :rmq_url:           (str) URI Connection string for RabbitMQ
+        :mq_hostname:       (str) Name of the host where RabbitMQ is running
+        :port:              (int) Port at which rabbitMQ can be accessed
 
     Currently, EnTK is configured to work with one pending queue and one
     completed queue. In the future, the number of queues can be varied for
@@ -43,7 +44,8 @@ class Base_TaskManager(object):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, sid, pending_queue, completed_queue, rmgr, rts, rmq_url):
+    def __init__(self, sid, pending_queue, completed_queue, rmgr, mq_hostname,
+                       port, rts):
 
         if not isinstance(sid, basestring):
             raise TypeError(expected_type=basestring,
@@ -57,21 +59,26 @@ class Base_TaskManager(object):
             raise TypeError(expected_type=basestring,
                             actual_type=type(completed_queue))
 
+        if not isinstance(mq_hostname, basestring):
+            raise TypeError(expected_type=basestring,
+                            actual_type=type(mq_hostname))
+
+        if not isinstance(port, int):
+            raise TypeError(expected_type=int,
+                            actual_type=type(port))
+
         if not isinstance(rmgr, Base_ResourceManager):
             raise TypeError(expected_type=Base_ResourceManager,
                             actual_type=type(rmgr))
-
-        if not isinstance(rmq_url, basestring):
-            raise TypeError(expected_type=basestring,
-                            actual_type=type(rmq_url))
 
 
         self._sid             = sid
         self._pending_queue   = pending_queue
         self._completed_queue = completed_queue
+        self._hostname        = mq_hostname
+        self._port            = port
         self._rmgr            = rmgr
         self._rts             = rts
-        self._rmq_url         = rmq_url
 
         # Utility parameters
         self._uid  = ru.generate_id('task_manager.%(item_counter)04d',
@@ -83,7 +90,8 @@ class Base_TaskManager(object):
         self._prof = ru.Profiler(name, path=self._path)
 
         # Thread should run till terminate condtion is encountered
-        mq_connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
+        mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
+                                                   host=mq_hostname, port=port))
 
         self._hb_request_q  = '%s-hb-request'  % self._sid
         self._hb_response_q = '%s-hb-response' % self._sid
@@ -107,7 +115,8 @@ class Base_TaskManager(object):
 
     # --------------------------------------------------------------------------
     #
-    def _tmgr(self, uid, rmgr, pending_queue, completed_queue, rmq_url):
+    def _tmgr(self, uid, rmgr, mq_hostname, port, pending_queue,
+                    completed_queue):
         """
         **Purpose**: Method to be run by the tmgr process. This method receives
                      a Task from the pending_queue and submits it to the RTS.
@@ -222,8 +231,8 @@ class Base_TaskManager(object):
 
             self._prof.prof('hbeat_start', uid=self._uid)
 
-            mq_connection = pika.BlockingConnection(pika.URLParameters(
-                                       self._rmq_url))
+            mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
+                                       host=self._hostname, port=self._port))
             mq_channel = mq_connection.channel()
 
             while not self._hb_terminate.is_set():
@@ -361,8 +370,8 @@ class Base_TaskManager(object):
 
             if not self.check_heartbeat() or self.check_manager():
 
-                conn = pika.BlockingConnection(pika.URLParameters(
-                                       self._rmq_url))
+                conn = pika.BlockingConnection(pika.ConnectionParameters(
+                                       host=self._hostname, port=self._port))
                 mq_channel = conn.channel()
 
                 # To respond to heartbeat - get request from rpc_queue

--- a/src/radical/entk/execman/mock/task_manager.py
+++ b/src/radical/entk/execman/mock/task_manager.py
@@ -33,7 +33,7 @@ class TaskManager(Base_TaskManager):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :rmq_conn_params:   (pika.connection.URLParameters) object of
+        :rmq_conn_params:   (pika.connection.ConnectionParameters) object of
                             parameters necessary to connect to RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one

--- a/src/radical/entk/execman/mock/task_manager.py
+++ b/src/radical/entk/execman/mock/task_manager.py
@@ -33,8 +33,7 @@ class TaskManager(Base_TaskManager):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :mq_hostname:       (str) Name of the host where RabbitMQ is running
-        :port:              (int) Port at which rabbitMQ can be accessed
+        :rmq_url:           (str) URI connection string for RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one
     completed queue. In the future, the number of queues can be varied for
@@ -44,11 +43,10 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, sid, pending_queue, completed_queue, rmgr, mq_hostname,
-                       port):
+    def __init__(self, sid, pending_queue, completed_queue, rmgr, rmq_url):
 
         super(TaskManager, self).__init__(sid, pending_queue, completed_queue,
-                                          rmgr, mq_hostname, port, rts='mock')
+                                          rmgr, rts='mock', rmq_url)
         self._rts_runner = None
 
         self._rmq_ping_interval = os.getenv('RMQ_PING_INTERVAL', 10)
@@ -59,8 +57,7 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _tmgr(self, uid, rmgr, mq_hostname, port, pending_queue,
-                    completed_queue):
+    def _tmgr(self, uid, rmgr, pending_queue, completed_queue, rmq_url):
         """
         **Purpose**: Method to be run by the tmgr process. This method receives
                      a Task from the pending_queue and submits it to the RTS.
@@ -122,7 +119,7 @@ class TaskManager(Base_TaskManager):
 
             # Acquire a connection+channel to the rmq server
             mq_connection = pika.BlockingConnection(
-                pika.ConnectionParameters(host=mq_hostname, port=port))
+                pika.URLParameters(rmq_url))
             mq_channel = mq_connection.channel()
 
             # Make sure the heartbeat response queue is empty
@@ -134,8 +131,7 @@ class TaskManager(Base_TaskManager):
 
             # Start second thread to receive tasks and push to RTS
             self._rts_runner = mt.Thread(target=self._process_tasks,
-                                         args=(task_queue, rmgr, mq_hostname,
-                                               port))
+                                         args=(task_queue, rmgr, rmq_url))
             self._rts_runner.start()
 
             self._prof.prof('tmgr infrastructure setup done', uid=uid)
@@ -188,7 +184,7 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _process_tasks(self, task_queue, rmgr, mq_hostname, port):
+    def _process_tasks(self, task_queue, rmgr, rmq_url):
         '''
         **Purpose**: The new thread that gets spawned by the main tmgr process
                      invokes this function. This function receives tasks from
@@ -214,8 +210,7 @@ class TaskManager(Base_TaskManager):
                     task.name)] = str(task.path)
         # ----------------------------------------------------------------------
 
-        mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                   host=mq_hostname, port=port))
+        mq_connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
         mq_channel = mq_connection.channel()
 
         try:
@@ -295,10 +290,9 @@ class TaskManager(Base_TaskManager):
                                             name='task-manager',
                                             args=(self._uid,
                                                   self._rmgr,
-                                                  self._hostname,
-                                                  self._port,
                                                   self._pending_queue,
-                                                  self._completed_queue)
+                                                  self._completed_queue,
+                                                  self._rmq_url)
                                             )
 
             self._log.info('Starting task manager process')

--- a/src/radical/entk/execman/mock/task_manager.py
+++ b/src/radical/entk/execman/mock/task_manager.py
@@ -33,8 +33,8 @@ class TaskManager(Base_TaskManager):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :mq_hostname:       (str) Name of the host where RabbitMQ is running
-        :port:              (int) Port at which rabbitMQ can be accessed
+        :rmq_conn_params:   (pika.connection.URLParameters) object of
+                            parameters necessary to connect to RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one
     completed queue. In the future, the number of queues can be varied for
@@ -44,11 +44,11 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, sid, pending_queue, completed_queue, rmgr, mq_hostname,
-                       port):
+    def __init__(self, sid, pending_queue, completed_queue, rmgr,
+                       rmq_conn_params):
 
         super(TaskManager, self).__init__(sid, pending_queue, completed_queue,
-                                          rmgr, mq_hostname, port, rts='mock')
+                                          rmgr, rmq_conn_params, rts='mock')
         self._rts_runner = None
 
         self._rmq_ping_interval = os.getenv('RMQ_PING_INTERVAL', 10)
@@ -59,8 +59,8 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _tmgr(self, uid, rmgr, mq_hostname, port, pending_queue,
-                    completed_queue):
+    def _tmgr(self, uid, rmgr, pending_queue, completed_queue,
+                    rmq_conn_params):
         """
         **Purpose**: Method to be run by the tmgr process. This method receives
                      a Task from the pending_queue and submits it to the RTS.
@@ -121,8 +121,7 @@ class TaskManager(Base_TaskManager):
             self._log.info('Task Manager process started')
 
             # Acquire a connection+channel to the rmq server
-            mq_connection = pika.BlockingConnection(
-                pika.ConnectionParameters(host=mq_hostname, port=port))
+            mq_connection = pika.BlockingConnection(rmq_conn_params)
             mq_channel = mq_connection.channel()
 
             # Make sure the heartbeat response queue is empty
@@ -134,8 +133,8 @@ class TaskManager(Base_TaskManager):
 
             # Start second thread to receive tasks and push to RTS
             self._rts_runner = mt.Thread(target=self._process_tasks,
-                                         args=(task_queue, rmgr, mq_hostname,
-                                               port))
+                                         args=(task_queue, rmgr,
+                                               rmq_conn_params))
             self._rts_runner.start()
 
             self._prof.prof('tmgr infrastructure setup done', uid=uid)
@@ -188,7 +187,7 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _process_tasks(self, task_queue, rmgr, mq_hostname, port):
+    def _process_tasks(self, task_queue, rmgr, rmq_conn_params):
         '''
         **Purpose**: The new thread that gets spawned by the main tmgr process
                      invokes this function. This function receives tasks from
@@ -214,8 +213,7 @@ class TaskManager(Base_TaskManager):
                     task.name)] = str(task.path)
         # ----------------------------------------------------------------------
 
-        mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                   host=mq_hostname, port=port))
+        mq_connection = pika.BlockingConnection(rmq_conn_params)
         mq_channel = mq_connection.channel()
 
         try:
@@ -295,10 +293,9 @@ class TaskManager(Base_TaskManager):
                                             name='task-manager',
                                             args=(self._uid,
                                                   self._rmgr,
-                                                  self._hostname,
-                                                  self._port,
                                                   self._pending_queue,
-                                                  self._completed_queue)
+                                                  self._completed_queue,
+                                                  self._rmq_conn_params)
                                             )
 
             self._log.info('Starting task manager process')

--- a/src/radical/entk/execman/rp/task_manager.py
+++ b/src/radical/entk/execman/rp/task_manager.py
@@ -38,7 +38,7 @@ class TaskManager(Base_TaskManager):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :rmq_conn_params:   (pika.connection.URLParameters) object of
+        :rmq_conn_params:   (pika.connection.ConnectionParameters) object of
                             parameters necessary to connect to RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one

--- a/src/radical/entk/execman/rp/task_manager.py
+++ b/src/radical/entk/execman/rp/task_manager.py
@@ -38,8 +38,8 @@ class TaskManager(Base_TaskManager):
                             finished execution. Currently, only one queue.
         :rmgr:              (ResourceManager) Object to be used to access the
                             Pilot where the tasks can be submitted
-        :mq_hostname:       (str) Name of the host where RabbitMQ is running
-        :port:              (int) Port at which rabbitMQ can be accessed
+        :rmq_conn_params:   (pika.connection.URLParameters) object of
+                            parameters necessary to connect to RabbitMQ
 
     Currently, EnTK is configured to work with one pending queue and one
     completed queue. In the future, the number of queues can be varied for
@@ -49,11 +49,11 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, sid, pending_queue, completed_queue, rmgr, mq_hostname,
-                       port):
+    def __init__(self, sid, pending_queue, completed_queue, rmgr,
+                       rmq_conn_params):
 
         super(TaskManager, self).__init__(sid, pending_queue, completed_queue,
-                                          rmgr, mq_hostname, port,
+                                          rmgr, rmq_conn_params,
                                           rts='radical.pilot')
         self._umgr       = None
         self._rts_runner = None
@@ -66,8 +66,8 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _tmgr(self, uid, umgr, rmgr, mq_hostname, port, pending_queue,
-                    completed_queue):
+    def _tmgr(self, uid, umgr, rmgr, pending_queue, completed_queue,
+                    rmq_conn_params):
         """
         **Purpose**: This method has 3 purposes: Respond to a heartbeat thread
                      indicating the live-ness of the RTS, receive tasks from the
@@ -141,8 +141,7 @@ class TaskManager(Base_TaskManager):
             self._log.info('Task Manager process started')
 
             # Acquire a connection+channel to the rmq server
-            mq_connection = pika.BlockingConnection(
-                pika.ConnectionParameters(host=mq_hostname, port=port))
+            mq_connection = pika.BlockingConnection(rmq_conn_params)
             mq_channel = mq_connection.channel()
 
             # Make sure the heartbeat response queue is empty
@@ -154,8 +153,8 @@ class TaskManager(Base_TaskManager):
 
             # Start second thread to receive tasks and push to RTS
             self._rts_runner = mt.Thread(target=self._process_tasks,
-                                         args=(task_queue, rmgr, mq_hostname,
-                                               port))
+                                         args=(task_queue, rmgr,
+                                               rmq_conn_params))
             self._rts_runner.start()
 
             self._prof.prof('tmgr infrastructure setup done', uid=uid)
@@ -208,7 +207,7 @@ class TaskManager(Base_TaskManager):
 
     # --------------------------------------------------------------------------
     #
-    def _process_tasks(self, task_queue, rmgr, mq_hostname, port):
+    def _process_tasks(self, task_queue, rmgr, rmq_conn_params):
         '''
         **Purpose**: The new thread that gets spawned by the main tmgr process
                      invokes this function. This function receives tasks from
@@ -244,9 +243,7 @@ class TaskManager(Base_TaskManager):
                 if unit.state in rp.FINAL:
 
                     # Acquire a connection+channel to the rmq server
-                    mq_connection = pika.BlockingConnection(
-                                        pika.ConnectionParameters(
-                                            host=mq_hostname, port=port))
+                    mq_connection = pika.BlockingConnection(rmq_conn_params)
                     mq_channel = mq_connection.channel()
 
                     task = None
@@ -313,9 +310,7 @@ class TaskManager(Base_TaskManager):
                     bulk_cuds.append(create_cud_from_task(
                                             task, placeholders, self._prof))
 
-                    mq_connection = pika.BlockingConnection(
-                                        pika.ConnectionParameters(
-                                            host=mq_hostname, port=port))
+                    mq_connection = pika.BlockingConnection(rmq_conn_params)
                     mq_channel = mq_connection.channel()
 
                     self._advance(task, 'Task', states.SUBMITTING,
@@ -357,10 +352,9 @@ class TaskManager(Base_TaskManager):
                                             args=(self._uid,
                                                   self._umgr,
                                                   self._rmgr,
-                                                  self._hostname,
-                                                  self._port,
                                                   self._pending_queue,
-                                                  self._completed_queue)
+                                                  self._completed_queue,
+                                                  self._rmq_conn_params)
                                             )
 
             self._log.info('Starting task manager process')


### PR DESCRIPTION
So, this pull request is better than the last one, but it may still have some problems. It extends the `AppManager` constructor to accept `rmq_url` as an input parameter. The original `hostname` and `port` parameters have been preserved, and they will override `rmq_url` if specified at the same time. To do this, a `pika.connection.URLParameters` object is created and then its values are overridden. Then, instead of passing the `hostname` and `port` from function to function in various forms, the connection parameters object, named `rmq_conn_params`, is passed instead. 

This makes a lot of things a lot easier, but the downside is that things might get weird if you ever try to create the downstream objects directly, such as `WFProcessor`. This may cause the tests to fail, if you have unit tests that test the previous interfaces. It was necessary to change the interfaces downstream from `AppManager`, however, or else credentials would not be propagated.