### PR TITLE
type conversion forced for rmq port

### DIFF
--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -117,6 +117,7 @@ class AppManager(object):
         self._sync_thread     = None
         self._terminate_sync  = mt.Event()
         self._resubmit_failed = False
+        self._port            = int(self._port)
 
         # Setup rabbitmq queues
         self._setup_mqs()


### PR DESCRIPTION
Quick Fix for Preventing incorrect data type i.e. string to RabbitMQ port number, part of Issue #384 