### PR TITLE
Global TOC on sphinx navigation sidebar 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,8 @@ html_theme = 'armstrong'
 #
 html_theme_options = {"collapsiblesidebar" : "true"}
 
+html_sidebars = { '**': ['globaltoc.html', 'relations.html', 'searchbox.html'] }
+
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ["_themes", ]
 


### PR DESCRIPTION
PR for #388, global TOC is presented, sourcelink is removed also. 

Summary, the current doc has 'localtoc', 'relations', 'sourcelink' and 'searchbox' where localtoc only shows current table of contents e.g. `1. Introduction` whereas 'globaldoc' presents from `1. Introduction` to `10. Developer Documentation` with 1 level of depth (not current).

Current:
```
Table of Contents
1. Introduction
1.1. Overview
1.1.1. Design
1.1.2. Dependencies
1.1.3. Five steps to create an application
1.2. Intended users
```

Updated:
```
Table of Contents
Contents:

1. Introduction
1.1. Overview
1.2. Intended users
2. Ensemble Toolkit
3. Installation
4. User Guide
5. Examples
6. Advanced Examples
7. API Reference for Users
8. Unit tests & Integration tests
9. Exceptions
10. Developer Documentation
```

Globaltoc seems a normal behavior for navigating pages.

This change can be applied to docs for rp.saga and pilot. @andre-merzky, any comment, thoughts? 