### PR TITLE
Travis fix with documentation update for python 3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 [run]
 concurrency = multiprocessing
 parallel = True
-source = VENV/lib/python2.7/site-packages/radical/entk
+source = VENV/lib/python3.7/site-packages/radical/entk
 
 # $ coverage run -m pytest -vvv test_*
 # $ coverage combine

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,6 @@ ignore-patterns=
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=
-init-hook='import sys;sys.path.append("/Users/hrlee/venv3/entk.copy.2/lib/python3.7/site-packages/")'
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,6 +16,7 @@ ignore-patterns=
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=
+init-hook='import sys;sys.path.append("/Users/hrlee/venv3/entk.copy.2/lib/python3.7/site-packages/")'
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/.pylintrc
+++ b/.pylintrc
@@ -138,7 +138,8 @@ disable=raising-format-tuple,
         C,
         R,
         relative-import,
-        bare-except
+        bare-except,
+        W0212
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,12 @@ before_install:
   - ssh localhost hostname
   - ssh localhost uname -a
 
+# Xenial needs rmq installation
+addons:
+  apt:
+    packages:
+    - rabbitmq-server
+
 # command to install dependencies
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: "2.7"
+python: "3.7"
 
 os:
   - linux
@@ -54,7 +54,7 @@ install:
   - pip install pytest-timeout
 
 before_script:
-  - LOC=/home/travis/virtualenv/python2.7  # Location where VE is created on travis
+  - LOC=/home/travis/virtualenv/python3.7  # Location where VE is created on travis
   - sed -i 's|VENV|'"$LOC"'|g' .coveragerc  # Update source in coveragerc
   - cat .coveragerc
 

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ The documentation for Ensemble Toolkit is available at
 [![conda](https://anaconda.org/conda-forge/radical.entk/badges/version.svg)](https://anaconda.org/conda-forge/radical.entk)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2b7c9d2858804fb49e2e5512ad0a57ec)](https://www.codacy.com/app/vivek-bala/radical.entk?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=radical-cybertools/radical.entk&amp;utm_campaign=Badge_Grade)
 
-<!-- coverage run --source $VENV/lib/python2.7/site-packages/radical/entk -m pytest -vvv $LOC/radical.entk/tests -->
+<!-- coverage run --source $VENV/lib/python3.7/site-packages/radical/entk -m pytest -vvv $LOC/radical.entk/tests -->
 <!-- coverage html -->

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Installation
 Installing Ensemble Toolkit
 ===========================
 
-Installing Ensemble Toolkit using Pypi, or Git
+Installing Ensemble Toolkit using virtualenv
 ----------------------------------------------
 
 To install the Ensemble Toolkit, we need to create a virtual environment. 
@@ -15,11 +15,27 @@ Open a terminal and run:
 
 .. code-block:: bash
 
-        virtualenv $HOME/myenv -p python3.7
-        source $HOME/myenv/bin/activate
+        virtualenv $HOME/ve-entk -p python3.7
+        source $HOME/ve-entk/bin/activate
 
-*`-p` params indicates which python version you use, python3.6+ is required*
+- ``-p`` params indicates which python version you use, python3.6+ is required
+- python2 installation is available with the ``0.72.1`` version. Read more at
+  the troubleshooting_
 
+Activate virtualenv by:
+
+.. code-block:: bash
+
+        source $HOME/ve-entk/bin/activate
+
+.. note:: Activated env name is indicated in the prompt like: ``(ve-entk) username@two:~$``
+
+Deactivate the virtualenv, if you want to disengage. Your python won't
+recognize EnTK after deactivation.  To deactivate, run:
+
+.. code-block:: bash
+
+        deactivate
 
 It is suggested to use the released version of EnTK which you can install
 by executing the following command in your virtualenv:
@@ -29,8 +45,9 @@ by executing the following command in your virtualenv:
         pip install radical.entk
 
 
-To install a specific branch of EnTK, e.g. `devel`, you will need to clone the
-repository and checkout the branch. You can do so using the following commands:
+To install a specific branch of EnTK, e.g. `devel` instead of using pip
+installation, you will need to clone the repository and checkout the branch.
+You can do so using the following commands:
 
 .. code-block:: bash
 
@@ -49,9 +66,9 @@ printed.
 
         radical-stack
 
-          python               : 3.6.9
+          python               : 3.7.4
           pythonpath           :
-          virtualenv           : /home/hrlee/venv3/entk.py36
+          virtualenv           : /home/username/ve-entk
 
           radical.entk         : 1.0.0
           radical.pilot        : 1.0.0
@@ -67,8 +84,8 @@ Open a terminal and run (assuming you have PATH to point to ``conda``):
 
 .. code-block:: bash
 
-        conda create -n ve-entk python=3.7 -y
-        conda activate ve-entk
+        conda create -n conda-entk python=3.7 -y
+        conda activate conda-entk
 
 
 It is suggested to use the released version of EnTK which you can install
@@ -321,6 +338,8 @@ you want to access, you will have to get the certificates from the corresponding
 information is available in their user guide.
 
 
+.. _troubleshooting:
+
 Troubleshooting
 =======================
 
@@ -335,8 +354,35 @@ If virtualenv **is not** installed on your system, you can try the following.
         wget --no-check-certificate http://pypi.python.org/packages/source/v/virtualenv/virtualenv-16.7.9.tar.gz
         tar xzf virtualenv-16.7.9.tar.gz
 
-        python virtualenv-16.7.9/virtualenv.py $HOME/myenv -p python3.7
-        source $HOME/myenv/bin/activate
+        python virtualenv-16.7.9/virtualenv.py $HOME/ve-entk -p python3.7
+        source $HOME/ve-entk/bin/activate
+
+**Python 2 legacy installation**
+
+As of January 1, 2020, Python 2 support is terminated by the Python Software
+Foundation but the previous release of EnTK i.e. ``0.72.1`` allows to use Python 2.
+PyPI installation with virtualenv is:
+
+.. code-block:: bash
+
+        virtualenv $HOME/ve-entk-py2 -p python2.7
+        source $HOME/ve-entk-py2/bin/activate
+        pip install radical.entk==0.72.1
+
+```radical-stack``` confirms the versions of the radical cybertools:
+
+.. code-block:: bash
+
+        $ radical-stack
+
+          python               : 2.7.17
+          pythonpath           :
+          virtualenv           : /home/username/ve-entk-py2
+
+          radical.entk         : 0.72.1
+          radical.pilot        : 0.73.1
+          radical.saga         : 0.72.1
+          radical.utils        : 0.72.0
 
 .. comments
         **TypeError: 'NoneType' object is not callable**

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,10 +16,9 @@ Open a terminal and run:
 .. code-block:: bash
 
         virtualenv $HOME/ve-entk -p python3.7
-        source $HOME/ve-entk/bin/activate
 
 - ``-p`` params indicates which python version you use, python3.6+ is required
-- python2 installation is available with the ``0.72.1`` version. Read more at
+- A legacy python2 installation is available with the ``0.72.1`` version. Hot fixes will be provided until Jul 2020. Read more at
   the troubleshooting_
 
 Activate virtualenv by:
@@ -45,7 +44,7 @@ by executing the following command in your virtualenv:
         pip install radical.entk
 
 
-To install a specific branch of EnTK, e.g. `devel` instead of using pip
+To install a specific branch of EnTK, e.g., `devel` instead of using pip
 installation, you will need to clone the repository and checkout the branch.
 You can do so using the following commands:
 
@@ -59,8 +58,8 @@ You can do so using the following commands:
 
 
 You can check the version of Ensemble Toolkit with the
-```radical-stack``` command-line tool. The current version should be
-printed.
+```radical-stack``` command-line tool. The currently installed version should
+be printed.
 
 .. code-block:: bash
 
@@ -97,8 +96,8 @@ by executing the following command in your conda env:
 
 
 You can check the version of Ensemble Toolkit with the
-```radical-stack``` command-line tool. The current version should be
-printed.
+```radical-stack``` command-line tool. The currently installed version should
+be printed.
 
 .. code-block:: bash
 
@@ -345,13 +344,13 @@ Troubleshooting
 
 **Missing virtualenv**
 
-This should return the version of the RADICAL-Pilot installation, e.g., `1.0.0`.
+This should return the version of the RCT installation, e.g., `1.0.0`.
 
 If virtualenv **is not** installed on your system, you can try the following.
 
 .. code-block:: bash
 
-        wget --no-check-certificate http://pypi.python.org/packages/source/v/virtualenv/virtualenv-16.7.9.tar.gz
+        wget --no-check-certificate https://pypi.python.org/packages/source/v/virtualenv/virtualenv-16.7.9.tar.gz
         tar xzf virtualenv-16.7.9.tar.gz
 
         python virtualenv-16.7.9/virtualenv.py $HOME/ve-entk -p python3.7
@@ -360,7 +359,7 @@ If virtualenv **is not** installed on your system, you can try the following.
 **Python 2 legacy installation**
 
 As of January 1, 2020, Python 2 support is terminated by the Python Software
-Foundation but the previous release of EnTK i.e. ``0.72.1`` allows to use Python 2.
+Foundation but the previous release of EnTK i.e. ``0.72.1`` allows to use Python 2.7.
 PyPI installation with virtualenv is:
 
 .. code-block:: bash
@@ -384,17 +383,3 @@ PyPI installation with virtualenv is:
           radical.saga         : 0.72.1
           radical.utils        : 0.72.0
 
-.. comments
-        **TypeError: 'NoneType' object is not callable**
-
-        Note that some Python installations have a broken multiprocessing module -- if you
-        experience the following error during installation::
-
-            Traceback (most recent call last):
-                File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
-                    func(*targs, **kargs)
-                File "/usr/lib/python2.7/multiprocessing/util.py", line 284, in _exit_function
-                    info('process shutting down')
-            TypeError: 'NoneType' object is not callable
-
-            you may need to move to Python 2.7 (see http://bugs.python.org/issue15881).

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -52,7 +52,7 @@ You can do so using the following commands:
 
         git clone https://github.com/radical-cybertools/radical.entk.git
         cd radical.entk
-        git checkout devel
+        git checkout <branch-name>
         pip install .
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,8 +15,10 @@ Open a terminal and run:
 
 .. code-block:: bash
 
-        virtualenv $HOME/myenv
+        virtualenv $HOME/myenv -p python3.7
         source $HOME/myenv/bin/activate
+
+*`-p` params indicates which python version you use, python3.6+ is required*
 
 
 It is suggested to use the released version of EnTK which you can install
@@ -27,26 +29,34 @@ by executing the following command in your virtualenv:
         pip install radical.entk
 
 
-To install a specific branch of EnTK, you will need to clone the repository
-and checkout the branch. You can do so using the following commands:
+To install a specific branch of EnTK, e.g. `devel`, you will need to clone the
+repository and checkout the branch. You can do so using the following commands:
 
 .. code-block:: bash
 
         git clone https://github.com/radical-cybertools/radical.entk.git
         cd radical.entk
-        git checkout <branch-name>
+        git checkout devel
         pip install .
 
 
 
 You can check the version of Ensemble Toolkit with the
-```radical-entk-version``` command-line tool. The current version should be
+```radical-stack``` command-line tool. The current version should be
 printed.
 
 .. code-block:: bash
 
-        radical-entk-version
-        0.70.0
+        radical-stack
+
+          python               : 3.6.9
+          pythonpath           :
+          virtualenv           : /home/hrlee/venv3/entk.py36
+
+          radical.entk         : 1.0.0
+          radical.pilot        : 1.0.0
+          radical.saga         : 1.0.0
+          radical.utils        : 1.0.0
 
 
 Installing Ensemble Toolkit using Anaconda/Conda
@@ -57,8 +67,8 @@ Open a terminal and run (assuming you have PATH to point to ``conda``):
 
 .. code-block:: bash
 
-        conda create -n ve-entk python=2.7 -y
-        source activate ve-entk
+        conda create -n ve-entk python=3.7 -y
+        conda activate ve-entk
 
 
 It is suggested to use the released version of EnTK which you can install
@@ -70,122 +80,150 @@ by executing the following command in your conda env:
 
 
 You can check the version of Ensemble Toolkit with the
-```radical-entk-version``` command-line tool. The current version should be
+```radical-stack``` command-line tool. The current version should be
 printed.
 
 .. code-block:: bash
 
-        radical-entk-version
-        0.70.0
+        radical-stack
+
+          python               : 3.6.9
+          pythonpath           :
+          virtualenv           : /home/hrlee/venv3/entk.py36
+
+          radical.entk         : 1.0.0
+          radical.pilot        : 1.0.0
+          radical.saga         : 1.0.0
+          radical.utils        : 1.0.0
 
 
-Installing Ensemble Toolkit using Docker
-----------------------------------------
 
-You can install Docker from their 
-`official documentation <https://hub.docker.com/search/?type=edition&offering=community>`_.
-Once you have installed Docker, you can use the following Dockerfile to build
-a container:
+.. comments
 
-.. code-block:: bash
+        Installing Ensemble Toolkit using Docker
+        ----------------------------------------
 
-        FROM ubuntu:16.04
+        You can install Docker from their 
+        `official documentation <https://hub.docker.com/search/?type=edition&offering=community>`_.
+        Once you have installed Docker, you can use the following Dockerfile to build
+        a container:
 
-        ENV RMQ_HOSTNAME=two.radical-project.org
-        ENV RMQ_PORT=33247
-        ENV RADICAL_PILOT_DBURL="mongodb://user:user@ds247688.mlab.com:47688/entk-docs"
+        .. code-block:: bash
 
-        RUN apt-get update \
-        && apt-get install wget curl python python-dev python-pip python-virtualenv bzip2 -y \
-        && virtualenv ~/ve-entk \
-        && . ~/ve-entk/bin/activate \
-        && pip install radical.entk
+                FROM ubuntu:16.04
 
-You can also download the Dockerfile :download:`here <./misc/Dockerfile>`.
+                ENV RMQ_HOSTNAME=two.radical-project.org
+                ENV RMQ_PORT=33247
+                ENV RADICAL_PILOT_DBURL="mongodb://user:user@ds247688.mlab.com:47688/entk-docs"
 
-You can build and execute the container by running:
+                RUN apt-get update \
+                && apt-get install wget curl python python-dev python-pip python-virtualenv bzip2 -y \
+                && virtualenv ~/ve-entk \
+                && . ~/ve-entk/bin/activate \
+                && pip install radical.entk
 
-.. code-block:: bash
+        You can also download the Dockerfile :download:`here <./misc/Dockerfile>`.
 
-        docker build -f ./Dockerfile -t entk .
-        docker run -t -i entk
+        You can build and execute the container by running:
 
-Once you execute the container, the default path will be /root (of the container).
-The EnTK virtualenv exists at ~/ve-entk (inside the container). This is useful
-to know as the examples exist inside the virtualenv.
+        .. code-block:: bash
 
-You can check the version of Ensemble Toolkit with the
-```radical-entk-version``` command-line tool. The current version should be
-printed.
+                docker build -f ./Dockerfile -t entk .
+                docker run -t -i entk
 
-.. code-block:: bash
+        Once you execute the container, the default path will be /root (of the container).
+        The EnTK virtualenv exists at ~/ve-entk (inside the container). This is useful
+        to know as the examples exist inside the virtualenv.
 
-        radical-entk-version
-        0.70.0
+        You can check the version of Ensemble Toolkit with the
+        ```radical-entk-version``` command-line tool. The current version should be
+        printed.
 
+        .. code-block:: bash
 
-Installing rabbitmq
-===================
-
-Installing rabbitmq as a system process (sudo privileges required)
-------------------------------------------------------------------
-
-Ensemble Toolkit relies on RabbitMQ for message transfers. Installation
-instructions can be found at <https://www.rabbitmq.com/download.html>. At
-the end of the installation run ```rabbitmq-server``` to start the server.
-RabbitMQ needs to be installed on the same machine as EnTK is installed.
-
-In some cases, you might have to explicitly start the rabbitmq-server after
-installation. You can check if the rabbitmq-server process is alive. If not,
-please run the following:
-
-.. code-block:: bash
-
-        rabbitmq-server -detached
+                radical-entk-version
+                0.70.0
 
 
-Installing rabbitmq using docker
---------------------------------
+RabbitMQ
+========
 
-If installing rabbitmq directly seems to be cumbersome, you can also install a
-docker instance of rabbitmq. Assuming you have docker installed, you can
-download and run the rabbitmq instance using the following command:
+Ensemble Toolkit relies on RabbitMQ for message transfers. RabbitMQ needs to be
+configured or it can be installed on the same machine as EnTK is installed.
+Installation instructions can be found at
+<https://www.rabbitmq.com/download.html>. At the end of the installation run
+```rabbitmq-server``` to start the server.
+
+The following configuration defines a default server and port number to communicate.
 
 .. code-block:: bash
 
-        docker run -d --name <name of instance> -P rabbitmq:3
+        export RMQ_HOSTNAME=two.radical-project.org; export RMQ_PORT=33239
+
+.. comments
+
+        Installing rabbitmq
+        ===================
+
+        Installing rabbitmq as a system process (sudo privileges required)
+        ------------------------------------------------------------------
+
+        Ensemble Toolkit relies on RabbitMQ for message transfers. Installation
+        instructions can be found at <https://www.rabbitmq.com/download.html>. At
+        the end of the installation run ```rabbitmq-server``` to start the server.
+        RabbitMQ needs to be installed on the same machine as EnTK is installed.
+
+        In some cases, you might have to explicitly start the rabbitmq-server after
+        installation. You can check if the rabbitmq-server process is alive. If not,
+        please run the following:
+
+        .. code-block:: bash
+
+                rabbitmq-server -detached
 
 
-The '-P' argument auto maps new ports from localhost to the ports expected by
-rabbitmq. This is useful if you want to have multiple EnTK scripts running as
-you would require multiple rabbitmq instances.
+        Installing rabbitmq using docker
+        --------------------------------
 
-You can see the mapping of the ports running ```docker ps```.
+        If installing rabbitmq directly seems to be cumbersome, you can also install a
+        docker instance of rabbitmq. Assuming you have docker installed, you can
+        download and run the rabbitmq instance using the following command:
 
-.. code-block:: bash
+        .. code-block:: bash
 
-        vivek@two:~$ docker run -d --name rabbit-1 -P rabbitmq:3
-        fb8ee8bfd822656a6338b7c19fa6a9641944f8bf5de5c1414fb78d049fdffc42
-        vivek@two:~$ docker ps
-        CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                                                                                 NAMES
-        fb8ee8bfd822        rabbitmq:3          "docker-entrypoint..."   9 seconds ago       Up 7 seconds        0.0.0.0:32777->4369/tcp, 0.0.0.0:32776->5671/tcp, 0.0.0.0:32775->5672/tcp, 0.0.0.0:32774->25672/tcp   rabbit-1
+                docker run -d --name <name of instance> -P rabbitmq:3
 
 
-Interactions between RabbitMQ and EnTK are done through port 5672 by default.
-For the above docker instance, we need to use port 32775. In your EnTK scripts,
-while creating the AppManager, you need to specify port=32775.
+        The '-P' argument auto maps new ports from localhost to the ports expected by
+        rabbitmq. This is useful if you want to have multiple EnTK scripts running as
+        you would require multiple rabbitmq instances.
 
-.. note::
-   If you are using Docker to install both EnTK and RabbitMQ, they should run
-   as two different containers. You can set the RMQ_PORT in the EnTK container
-   accordingly.
+        You can see the mapping of the ports running ```docker ps```.
 
-Installation Video
-==================
+        .. code-block:: bash
 
-.. raw:: html
+                vivek@two:~$ docker run -d --name rabbit-1 -P rabbitmq:3
+                fb8ee8bfd822656a6338b7c19fa6a9641944f8bf5de5c1414fb78d049fdffc42
+                vivek@two:~$ docker ps
+                CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                                                                                 NAMES
+                fb8ee8bfd822        rabbitmq:3          "docker-entrypoint..."   9 seconds ago       Up 7 seconds        0.0.0.0:32777->4369/tcp, 0.0.0.0:32776->5671/tcp, 0.0.0.0:32775->5672/tcp, 0.0.0.0:32774->25672/tcp   rabbit-1
 
-        <video controls width="800" src="_static/entk_installation_get_started.mp4"></video>
+
+        Interactions between RabbitMQ and EnTK are done through port 5672 by default.
+        For the above docker instance, we need to use port 32775. In your EnTK scripts,
+        while creating the AppManager, you need to specify port=32775.
+
+        .. note::
+           If you are using Docker to install both EnTK and RabbitMQ, they should run
+           as two different containers. You can set the RMQ_PORT in the EnTK container
+           accordingly.
+
+        Installation Video
+        ==================
+
+        .. raw:: html
+
+                <video controls width="800" src="_static/entk_installation_get_started.mp4"></video>
 
 
 Preparing the Environment
@@ -197,54 +235,56 @@ GSISSH, but it requires (a) a MongoDB server and (b) a properly set-up
 passwordless SSH/GSISSH environment.
 
 
-MongoDB Server
---------------
+.. comments
 
-.. figure:: figures/hosts_and_ports.png
-     :width: 360pt
-     :align: center
-     :alt: MongoDB and SSH ports.
+        MongoDB Server
+        --------------
 
-The MongoDB server is used to store and retrieve operational data during the
-execution of an application using RADICAL-Pilot. The MongoDB server must
-be reachable on **port 27017** from **both**, the host that runs the
-Ensemble Toolkit application and the host that executes the MD tasks, i.e.,
-the HPC cluster (see blue arrows in the figure above). In our experience,
-a small VM instance (e.g., Amazon AWS) works exceptionally well for this.
+        .. figure:: figures/hosts_and_ports.png
+             :width: 360pt
+             :align: center
+             :alt: MongoDB and SSH ports.
 
-.. warning:: If you want to run your application on your laptop or private
-            workstation, but run your MD tasks on a remote HPC cluster,
-            installing MongoDB on your laptop or workstation won't work.
-            Your laptop or workstation usually does not have a public IP
-            address and is hidden behind a masked and firewalled home or office
-            network. This means that the components running on the HPC cluster
-            will not be able to access the MongoDB server.
+        The MongoDB server is used to store and retrieve operational data during the
+        execution of an application using RADICAL-Pilot. The MongoDB server must
+        be reachable on **port 27017** from **both**, the host that runs the
+        Ensemble Toolkit application and the host that executes the MD tasks, i.e.,
+        the HPC cluster (see blue arrows in the figure above). In our experience,
+        a small VM instance (e.g., Amazon AWS) works exceptionally well for this.
 
-A MongoDB server can support more than one user. In an environment where
-multiple users use Ensemble Toolkit, a single MongoDB server
-for all users / hosts is usually sufficient.
+        .. warning:: If you want to run your application on your laptop or private
+                    workstation, but run your MD tasks on a remote HPC cluster,
+                    installing MongoDB on your laptop or workstation won't work.
+                    Your laptop or workstation usually does not have a public IP
+                    address and is hidden behind a masked and firewalled home or office
+                    network. This means that the components running on the HPC cluster
+                    will not be able to access the MongoDB server.
 
-**Install your own MongoDB**
+        A MongoDB server can support more than one user. In an environment where
+        multiple users use Ensemble Toolkit, a single MongoDB server
+        for all users / hosts is usually sufficient.
 
-Once you have identified a host that can serve as the new home for MongoDB,
-installation is straight forward. You can either install the MongoDB
-server package that is provided by most Linux distributions, or
-follow the installation instructions on the MongoDB website:
+        **Install your own MongoDB**
 
-http://docs.mongodb.org/manual/installation/
+        Once you have identified a host that can serve as the new home for MongoDB,
+        installation is straight forward. You can either install the MongoDB
+        server package that is provided by most Linux distributions, or
+        follow the installation instructions on the MongoDB website:
 
-**MongoDB-as-a-Service**
+        http://docs.mongodb.org/manual/installation/
 
-There are multiple commercial providers of hosted MongoDB services, some of them
-offer free usage tiers. We have had some good experience with the following:
+        **MongoDB-as-a-Service**
 
-* https://mongolab.com/
+        There are multiple commercial providers of hosted MongoDB services, some of them
+        offer free usage tiers. We have had some good experience with the following:
+
+        * https://mongolab.com/
 
 
 .. _ssh_gsissh_setup:
 
-Setup passwordless SSH Access to machines
------------------------------------------
+Setup passwordless SSH Access to HPC resources
+----------------------------------------------
 
 In order to create a passwordless access to another machine, you need to create a RSA key on your local machine
 and paste the public key into the `authorizes_users` list on the remote machine.
@@ -268,8 +308,8 @@ Now you can login to the machine by ``ssh machine1``.
 Source: http://nerderati.com/2011/03/17/simplify-your-life-with-an-ssh-config-file/
 
 
-Setup GSISSH Access to a machine
----------------------------------
+Setup GSISSH Access to HPC resources
+------------------------------------
 
 Setting up GSISSH access to a machine is a bit more complicated. We have documented the steps to setup GSISSH on
 `Ubuntu <https://github.com/vivek-bala/docs/blob/master/misc/gsissh_setup_stampede_ubuntu_xenial.sh>`_ (tested for
@@ -286,28 +326,29 @@ Troubleshooting
 
 **Missing virtualenv**
 
-This should return the version of the RADICAL-Pilot installation, e.g., `0.X.Y`.
+This should return the version of the RADICAL-Pilot installation, e.g., `1.0.0`.
 
 If virtualenv **is not** installed on your system, you can try the following.
 
 .. code-block:: bash
 
-        wget --no-check-certificate https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.9.tar.gz
-        tar xzf virtualenv-1.9.tar.gz
+        wget --no-check-certificate http://pypi.python.org/packages/source/v/virtualenv/virtualenv-16.7.9.tar.gz
+        tar xzf virtualenv-16.7.9.tar.gz
 
-        python virtualenv-1.9/virtualenv.py $HOME/myenv
+        python virtualenv-16.7.9/virtualenv.py $HOME/myenv -p python3.7
         source $HOME/myenv/bin/activate
 
-**TypeError: 'NoneType' object is not callable**
+.. comments
+        **TypeError: 'NoneType' object is not callable**
 
-Note that some Python installations have a broken multiprocessing module -- if you
-experience the following error during installation::
+        Note that some Python installations have a broken multiprocessing module -- if you
+        experience the following error during installation::
 
-    Traceback (most recent call last):
-        File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
-            func(*targs, **kargs)
-        File "/usr/lib/python2.7/multiprocessing/util.py", line 284, in _exit_function
-            info('process shutting down')
-    TypeError: 'NoneType' object is not callable
+            Traceback (most recent call last):
+                File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
+                    func(*targs, **kargs)
+                File "/usr/lib/python2.7/multiprocessing/util.py", line 284, in _exit_function
+                    info('process shutting down')
+            TypeError: 'NoneType' object is not callable
 
-    you may need to move to Python 2.7 (see http://bugs.python.org/issue15881).
+            you may need to move to Python 2.7 (see http://bugs.python.org/issue15881).

--- a/docs/user_guide/get_started.rst
+++ b/docs/user_guide/get_started.rst
@@ -16,14 +16,16 @@ You can download the complete code discussed in this section :download:`here <..
 your virtualenv under ``share/radical.entk/user_guide/scripts``.
 
 
-Use pre-configured MongoDB
-==========================
+.. comments
 
-For the purposes of this user guide, we have a MongoDB setup to use. Please run the following command to use it:
+        Use pre-configured MongoDB
+        ==========================
 
-.. code-block:: bash
+        For the purposes of this user guide, we have a MongoDB setup to use. Please run the following command to use it:
 
-        export RADICAL_PILOT_DBURL="mongodb://user:user@ds247688.mlab.com:47688/entk-docs"
+        .. code-block:: bash
+
+                export RADICAL_PILOT_DBURL="mongodb://user:user@ds247688.mlab.com:47688/entk-docs"
 
 
 Importing components from the Ensemble Toolkit Module
@@ -33,7 +35,7 @@ To create any application using Ensemble Toolkit, you need to import five module
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 1    
+    :lines: 3
     :linenos:
 
 
@@ -48,17 +50,17 @@ In the below snippet, we first create a Pipeline then a Stage.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 20-24
+    :lines: 22-26
     :linenos:
-    :lineno-start: 20
+    :lineno-start: 22
 
 Next, we create a Task and assign its name, executable and arguments of the executable.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 26-30
+    :lines: 28-32
     :linenos:
-    :lineno-start: 26
+    :lineno-start: 28
 
 
 Now, that we have a fully described Task, a Stage and a Pipeline. We create our workflow by adding the Task to the
@@ -66,9 +68,9 @@ Stage and adding the Stage to the Pipeline.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 32-36
+    :lines: 34-38
     :linenos:
-    :lineno-start: 32
+    :lineno-start: 34
 
 
 Creating the AppManager 
@@ -81,9 +83,9 @@ AppManager and ``run`` our application.
 
 .. literalinclude:: ../../examples/user_guide/get_started.py
     :language: python
-    :lines: 38-59
+    :lines: 40-61
     :linenos:
-    :lineno-start: 38
+    :lineno-start: 40
 
 
 
@@ -95,7 +97,8 @@ To run the script, simply execute the following from the command line:
 
 
 And that's it! That's all the steps in this example. You can generate more verbose output
-by setting the environment variable ``RADICAL_ENTK_VERBOSE=DEBUG``.
+by setting the environment variable **``export  RADICAL_LOG_TGT=radical.log;
+export RADICAL_LOG_LVL=DEBUG``**.
 
 Let's look at the complete code for this example:
 

--- a/docs/user_guide/get_started.rst
+++ b/docs/user_guide/get_started.rst
@@ -16,18 +16,6 @@ You can download the complete code discussed in this section :download:`here <..
 your virtualenv under ``share/radical.entk/user_guide/scripts``.
 
 
-.. comments
-
-        Use pre-configured MongoDB
-        ==========================
-
-        For the purposes of this user guide, we have a MongoDB setup to use. Please run the following command to use it:
-
-        .. code-block:: bash
-
-                export RADICAL_PILOT_DBURL="mongodb://user:user@ds247688.mlab.com:47688/entk-docs"
-
-
 Importing components from the Ensemble Toolkit Module
 ===========================================================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+git://github.com/radical-cybertools/radical.pilot@devel

--- a/setup.py
+++ b/setup.py
@@ -137,9 +137,9 @@ def get_version(mod_root):
 
 
 # ------------------------------------------------------------------------------
-# check python version. we need >= 3.5
+# check python version. we need >= 3.6
 if  sys.hexversion <= 0x03050000:
-    raise RuntimeError('%s requires Python 3.5 or higher' % name)
+    raise RuntimeError('%s requires Python 3.6 or higher' % name)
 
 
 # ------------------------------------------------------------------------------
@@ -170,7 +170,7 @@ class RunTwine(Command):
 # ------------------------------------------------------------------------------
 #
 if  sys.hexversion <= 0x03050000:
-    raise RuntimeError('SETUP ERROR: %s requires Python 3.5 or higher' % name)
+    raise RuntimeError('SETUP ERROR: %s requires Python 3.6 or higher' % name)
 
 
 # ------------------------------------------------------------------------------
@@ -204,7 +204,7 @@ setup_args = {
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Utilities',
         'Topic :: System :: Distributed Computing',
         'Topic :: Scientific/Engineering',

--- a/setup.py
+++ b/setup.py
@@ -96,18 +96,18 @@ def get_version(_mod_root):
             'not-a-git-repo' in _version_detail or \
             'not-found'      in _version_detail or \
             'fatal'          in _version_detail :
-            version = _version_base
+            _version = _version_base
         elif '@' not in _version_base:
-            version = '%s-%s' % (_version_base, _version_detail)
+            _version = '%s-%s' % (_version_base, _version_detail)
         else:
-            version = _version_base
+            _version = _version_base
 
         # make sure the version files exist for the runtime version inspection
         path = '%s/%s' % (src_root, _mod_root)
         with open(path + '/VERSION', 'w') as f:
-            f.write(version + '\n')
+            f.write(_version + '\n')
 
-        _sdist_name = '%s-%s.tar.gz' % (name, version)
+        _sdist_name = '%s-%s.tar.gz' % (name, _version)
         _sdist_name = _sdist_name.replace('/', '-')
         _sdist_name = _sdist_name.replace('@', '-')
         _sdist_name = _sdist_name.replace('#', '-')

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -370,7 +370,6 @@ def test_amgr_setup_mqs():
         mq_channel.queue_delete(queue=q)
 
 
-
 # ------------------------------------------------------------------------------
 #
 def test_amgr_cleanup_mqs():

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -312,9 +312,9 @@ def test_amgr_resource_terminate():
     amgr._task_manager = TaskManager(sid='test',
                                      pending_queue=list(),
                                      completed_queue=list(),
-                                     rmq_conn_params=amgr._rmq_conn_params,
                                      rmgr=amgr._rmgr,
-                                     rts='radical.pilot')
+                                     rmq_conn_params=amgr._rmq_conn_params)
+
     amgr.resource_terminate()
     # FIXME: what is tested (asserted) here?  What happens if terminate fails?
 
@@ -338,10 +338,9 @@ def test_amgr_terminate():
     amgr._task_manager = TaskManager(sid='test',
                                      pending_queue=list(),
                                      completed_queue=list(),
-                                     rmq_conn_params=amgr._rmq_conn_params,
                                      rmgr=amgr._rmgr,
-                                     rts='radica.pilot'
-                                     )
+                                     rmq_conn_params=amgr._rmq_conn_params)
+
     amgr.terminate()
     # FIXME: what is tested (asserted) here?  What happens if terminate fails?
 

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -164,6 +164,8 @@ def test_amgr_read_config():
     amgr._read_config(config_path='./',
                       hostname=None,
                       port=None,
+                      username=None,
+                      password=None,
                       reattempts=None,
                       resubmit_failed=None,
                       autoterminate=None,
@@ -310,9 +312,9 @@ def test_amgr_resource_terminate():
     amgr._task_manager = TaskManager(sid='test',
                                      pending_queue=list(),
                                      completed_queue=list(),
-                                     mq_hostname=amgr._hostname,
+                                     rmq_conn_params=amgr._rmq_conn_params,
                                      rmgr=amgr._rmgr,
-                                     port=amgr._port)
+                                     rts='radical.pilot')
     amgr.resource_terminate()
     # FIXME: what is tested (asserted) here?  What happens if terminate fails?
 
@@ -336,9 +338,9 @@ def test_amgr_terminate():
     amgr._task_manager = TaskManager(sid='test',
                                      pending_queue=list(),
                                      completed_queue=list(),
-                                     mq_hostname=amgr._hostname,
+                                     rmq_conn_params=amgr._rmq_conn_params,
                                      rmgr=amgr._rmgr,
-                                     port=amgr._port
+                                     rts='radica.pilot'
                                      )
     amgr.terminate()
     # FIXME: what is tested (asserted) here?  What happens if terminate fails?
@@ -453,8 +455,7 @@ def test_amgr_synchronizer():
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=host,
-                    port=port,
+                    rmq_conn_params=amgr._rmq_conn_params,
                     rts=None)
 
     amgr._rmgr         = rmgr

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -369,13 +369,6 @@ def test_amgr_setup_mqs():
     for q in qs:
         mq_channel.queue_delete(queue=q)
 
-    with open('.%s.txt' % amgr._sid, 'r') as fp:
-        lines = fp.readlines()
-
-    for ind, val in enumerate(lines):
-        lines[ind] = val.strip()
-
-    assert set(qs) == set(lines)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -37,8 +37,7 @@ settings.load_profile("travis")
 
 # ------------------------------------------------------------------------------
 #
-@mock.patch.object(Amgr, '_setup_mqs', return_value=None)
-def test_amgr_rmq_auth(mocked_setup_mqs):
+def test_amgr_rmq_auth():
 
     amgr_name = ru.generate_id('test.amgr.%(item_counter)04d', ru.ID_CUSTOM)
     amgr      = Amgr(hostname=host, port=port, username=user, password=passwd,

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -27,8 +27,8 @@ from radical.entk.execman.base import Base_ResourceManager as BaseRmgr
 
 host     =     os.environ.get('RMQ_HOSTNAME', 'localhost')
 port     = int(os.environ.get('RMQ_PORT',      5672))
-user     = 'foo'
-passwd   = 'bar'
+user     = 'guest'
+passwd   = 'guest'
 
 # Hypothesis settings
 settings.register_profile("travis", max_examples=100, deadline=None)
@@ -146,8 +146,8 @@ def test_amgr_read_config():
 
     d = {"hostname"       : "radical.two",
          "port"           : 25672,
-         "username"       : "guest",
-         "password"       : "guest",
+         "username"       : user,
+         "password"       : passwd,
          "reattempts"     : 5,
          "resubmit_failed": True,
          "autoterminate"  : False,

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -4,11 +4,6 @@ import os
 import pika
 import pytest
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 from   hypothesis      import settings
 
 import threading       as mt

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -129,10 +129,8 @@ def test_amgr_initialization():
 #
 def test_amgr_read_config():
 
-    amgr = Amgr()
+    amgr = Amgr(hostname=host, port=port)
 
-    assert amgr._hostname   == 'localhost'
-    assert amgr._port       == 5672
     assert amgr._reattempts == 3
 
     assert amgr._rmq_cleanup
@@ -149,6 +147,8 @@ def test_amgr_read_config():
 
     d = {"hostname"       : "radical.two",
          "port"           : 25672,
+         "username"       : "guest",
+         "password"       : "guest",
          "reattempts"     : 5,
          "resubmit_failed": True,
          "autoterminate"  : False,

--- a/tests/test_component/test_states.py
+++ b/tests/test_component/test_states.py
@@ -42,7 +42,8 @@ def test_pipeline_states():
     assert states._pipeline_state_inv == {1: states.INITIAL,
                                           2: states.SCHEDULING,
                                           3: states.SUSPENDED,
-                                          10: [states.FAILED, states.CANCELED, states.DONE]
+                                          10: [states.DONE, states.FAILED,
+                                              states.CANCELED]
                                           }
 
 
@@ -58,7 +59,8 @@ def test_stage_states():
     assert states._stage_state_inv == {1: states.INITIAL,
                                        2: states.SCHEDULING,
                                        4: states.SCHEDULED,
-                                       10: [states.FAILED, states.CANCELED, states.DONE]
+                                       10: [states.DONE, states.FAILED,
+                                           states.CANCELED]
                                        }
 
 
@@ -80,5 +82,5 @@ def test_task_states():
         4: states.SCHEDULED,
         5: states.SUBMITTING,
         7: states.COMPLETED,
-        10: [states.FAILED, states.CANCELED, states.DONE]
+        10: [states.DONE, states.FAILED, states.CANCELED]
     }

--- a/tests/test_component/test_tmgr.py
+++ b/tests/test_component/test_tmgr.py
@@ -334,8 +334,7 @@ def test_tmgr_mock_initialization(s, l, i):
     assert tmgr._uid               == 'task_manager.0000'
     assert tmgr._pending_queue     == ['pending']
     assert tmgr._completed_queue   == ['completed']
-    assert tmgr._hostname          == hostname
-    assert tmgr._port              == port
+    assert tmgr.rmq_conn_params    == rmq_conn_params
     assert tmgr._rts               == 'mock'
 
     assert tmgr._log
@@ -437,8 +436,7 @@ def test_tmgr_rp_initialization(s, l, i):
 
     assert tmgr._pending_queue   == ['pending']
     assert tmgr._completed_queue == ['completed']
-    assert tmgr._hostname        == hostname
-    assert tmgr._port            == port
+    assert tmgr._rmq_conn_params == rmq_conn_params
     assert tmgr._rts             == 'radical.pilot'
     assert tmgr._umgr            is None
     assert tmgr._tmgr_process    is None

--- a/tests/test_component/test_tmgr.py
+++ b/tests/test_component/test_tmgr.py
@@ -314,14 +314,6 @@ def test_tmgr_base_methods():
        i=st.integers())
 def test_tmgr_mock_initialization(s, l, i):
 
-    try:
-        home   = os.environ.get('HOME', '/home')
-        folder = glob.glob('%s/.radical/utils/test.*' % home)
-        for f in folder:
-            shutil.rmtree(f)
-    except:
-        pass
-
     rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0010'
     rmgr = MockRmgr(resource_desc={}, sid=sid)
@@ -331,10 +323,9 @@ def test_tmgr_mock_initialization(s, l, i):
                     rmgr=rmgr,
                     rmq_conn_params=rmq_conn_params)
 
-    assert tmgr._uid               == 'task_manager.0000'
     assert tmgr._pending_queue     == ['pending']
     assert tmgr._completed_queue   == ['completed']
-    assert tmgr.rmq_conn_params    == rmq_conn_params
+    assert tmgr._rmq_conn_params    == rmq_conn_params
     assert tmgr._rts               == 'mock'
 
     assert tmgr._log

--- a/tests/test_component/test_tmgr.py
+++ b/tests/test_component/test_tmgr.py
@@ -37,10 +37,7 @@ os.environ['ENTK_HB_INTERVAL'] = '5'
 
 # ------------------------------------------------------------------------------
 #
-@given(s=st.text(),
-       l=st.lists(st.characters()),
-       i=st.integers())
-def test_tmgr_base_initialization(s, l, i):
+def test_tmgr_base_initialization():
 
     try:
         home   = os.environ.get('HOME', '/home')
@@ -111,10 +108,10 @@ def test_tmgr_base_assignment_exceptions(s, l, i, b, se, di):
 
 # ------------------------------------------------------------------------------
 #
-def func_for_heartbeat_test(mq_hostname, port, hb_request_q, hb_response_q):
+def func_for_heartbeat_test(mq_hostname, mq_port, hb_request_q, hb_response_q):
 
     mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                   host=mq_hostname, port=port))
+                                                   host=mq_hostname, port=mq_port))
     mq_channel = mq_connection.channel()
 
     while True:
@@ -309,10 +306,7 @@ def test_tmgr_base_methods():
 
 # ------------------------------------------------------------------------------
 #
-@given(s=st.text(),
-       l=st.lists(st.characters()),
-       i=st.integers())
-def test_tmgr_mock_initialization(s, l, i):
+def test_tmgr_mock_initialization():
 
     rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0010'
@@ -339,10 +333,10 @@ def test_tmgr_mock_initialization(s, l, i):
 
 # ------------------------------------------------------------------------------
 #
-def func_for_mock_tmgr_test(mq_hostname, port, pending_queue, completed_queue):
+def func_for_mock_tmgr_test(mq_hostname, mq_port, pending_queue, completed_queue):
 
     mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                   host=mq_hostname, port=port))
+                                                   host=mq_hostname, port=mq_port))
     mq_channel = mq_connection.channel()
 
     tasks = list()
@@ -359,7 +353,7 @@ def func_for_mock_tmgr_test(mq_hostname, port, pending_queue, completed_queue):
     cnt = 0
     while cnt < 15:
 
-        method_frame, props, body = mq_channel.basic_get(queue=completed_queue)
+        method_frame, _, body = mq_channel.basic_get(queue=completed_queue)
 
         if not body:
             continue
@@ -406,10 +400,7 @@ def test_tmgr_mock_tmgr():
 
 # ------------------------------------------------------------------------------
 #
-@given(s=st.text(),
-       l=st.lists(st.characters()),
-       i=st.integers())
-def test_tmgr_rp_initialization(s, l, i):
+def test_tmgr_rp_initialization():
 
     sid  = ru.generate_id('test', ru.ID_UNIQUE)
     cfg  = {"sandbox_cleanup": False,

--- a/tests/test_component/test_tmgr.py
+++ b/tests/test_component/test_tmgr.py
@@ -51,21 +51,20 @@ def test_tmgr_base_initialization(s, l, i):
     except:
         pass
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0001'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     assert tmgr._uid             == 'task_manager.0000'
     assert tmgr._pending_queue   == ['pending-1']
     assert tmgr._completed_queue == ['completed-1']
-    assert tmgr._hostname        == hostname
-    assert tmgr._port            == port
+    assert tmgr._rmq_conn_params == rmq_conn_params
     assert tmgr._rts             is None
 
     assert tmgr._log
@@ -89,6 +88,7 @@ def test_tmgr_base_assignment_exceptions(s, l, i, b, se, di):
 
     sid = 'test.0002'
     rmgr = BaseRmgr({}, sid, None, {})
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     data_type = [s, l, i, b, se, di]
 
@@ -99,14 +99,14 @@ def test_tmgr_base_assignment_exceptions(s, l, i, b, se, di):
             with pytest.raises(ree.TypeError):
 
                 BaseTmgr(sid=s, pending_queue=s, completed_queue=s,
-                         rmgr=rmgr, mq_hostname=s, port=d, rts=None)
+                         rmgr=rmgr, rmq_conn_params=rmq_conn_params, rts=None)
 
         if not isinstance(d, int):
 
             with pytest.raises(ree.TypeError):
 
                 BaseTmgr(sid=s, pending_queue=s, completed_queue=s,
-                         rmgr=rmgr, mq_hostname=s, port=d, rts=None)
+                         rmgr=rmgr, rmq_conn_params=rmq_conn_params, rts=None)
 
 
 # ------------------------------------------------------------------------------
@@ -139,14 +139,14 @@ def func_for_heartbeat_test(mq_hostname, port, hb_request_q, hb_response_q):
 #
 def test_tmgr_base_heartbeat():
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0003'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     tmgr._hb_terminate = mt.Event()
@@ -165,14 +165,14 @@ def test_tmgr_base_heartbeat():
 #
 def test_tmgr_base_start_heartbeat():
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0004'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     assert     tmgr.start_heartbeat()
@@ -190,14 +190,14 @@ def test_tmgr_base_start_heartbeat():
 #
 def test_tmgr_base_terminate_heartbeat():
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0005'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     tmgr._hb_terminate = mt.Event()
@@ -217,14 +217,14 @@ def test_tmgr_base_terminate_heartbeat():
 #
 def test_tmgr_base_terminate_manager():
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0006'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     tmgr._tmgr_process   = mp.Process(target=tmgr._tmgr, name='heartbeat')
@@ -240,14 +240,14 @@ def test_tmgr_base_terminate_manager():
 #
 def test_tmgr_base_check_heartbeat():
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0007'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     tmgr._hb_thread    = mt.Thread(target=tmgr._heartbeat, name='heartbeat')
@@ -263,14 +263,14 @@ def test_tmgr_base_check_heartbeat():
 #
 def test_tmgr_base_check_manager():
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0008'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     tmgr._tmgr_process = mp.Process(target=tmgr._tmgr, name='heartbeat')
@@ -286,21 +286,20 @@ def test_tmgr_base_check_manager():
 #
 def test_tmgr_base_methods():
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0009'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     with pytest.raises(NotImplementedError):
         tmgr._tmgr(uid=None,
                    rmgr=None,
-                   mq_hostname=None,
-                   port=None,
+                   rmq_conn_params=None,
                    pending_queue=None,
                    completed_queue=None)
 
@@ -323,14 +322,14 @@ def test_tmgr_mock_initialization(s, l, i):
     except:
         pass
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     sid  = 'test.0010'
     rmgr = MockRmgr(resource_desc={}, sid=sid)
     tmgr = MockTmgr(sid=sid,
                     pending_queue=['pending'],
                     completed_queue=['completed'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port)
+                    rmq_conn_params=rmq_conn_params)
 
     assert tmgr._uid               == 'task_manager.0000'
     assert tmgr._pending_queue     == ['pending']
@@ -397,13 +396,13 @@ def test_tmgr_mock_tmgr():
                 'cpus'    : 20,
                 'project' : 'Random'}
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     rmgr = MockRmgr(resource_desc=res_dict, sid='test.0018')
     tmgr = MockTmgr(sid='test.0019',
                     pending_queue=['pendingq-1'],
                     completed_queue=['completedq-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port)
+                    rmq_conn_params=rmq_conn_params)
 
     tmgr.start_manager()
 
@@ -426,13 +425,13 @@ def test_tmgr_rp_initialization(s, l, i):
     cfg  = {"sandbox_cleanup": False,
             "db_cleanup"     : False}
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
     rmgr = RPRmgr({}, sid, cfg)
     tmgr = RPTmgr(sid=sid,
                   pending_queue=['pending'],
                   completed_queue=['completed'],
                   rmgr=rmgr,
-                  mq_hostname=hostname,
-                  port=port)
+                  rmq_conn_params=rmq_conn_params)
 
     assert 'task_manager' in tmgr._uid
 

--- a/tests/test_component/test_tmgr_2.py
+++ b/tests/test_component/test_tmgr_2.py
@@ -19,10 +19,10 @@ os.environ['ENTK_HB_INTERVAL'] = '5'
 
 # ------------------------------------------------------------------------------
 #
-def func_for_mock_tmgr_test(mq_hostname, port, pending_queue, completed_queue):
+def func_for_mock_tmgr_test(mq_hostname, mq_port, pending_queue, completed_queue):
 
     mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                   host=mq_hostname, port=port))
+                                                   host=mq_hostname, port=mq_port))
     mq_channel = mq_connection.channel()
 
     tasks = list()
@@ -41,7 +41,7 @@ def func_for_mock_tmgr_test(mq_hostname, port, pending_queue, completed_queue):
     cnt = 0
     while cnt < 15:
 
-        method_frame, props, body = mq_channel.basic_get(queue=completed_queue)
+        method_frame, _, body = mq_channel.basic_get(queue=completed_queue)
 
         if not body:
             continue

--- a/tests/test_component/test_tmgr_2.py
+++ b/tests/test_component/test_tmgr_2.py
@@ -68,6 +68,7 @@ def test_tmgr_rp_tmgr():
                 "db_cleanup"     : False}
     rmgr_id  = ru.generate_id('test', ru.ID_UNIQUE)
     rmgr     = RPRmgr(resource_desc=res_dict, sid=rmgr_id, rts_config=config)
+    mq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     rmgr._validate_resource_desc()
     rmgr._populate()
@@ -77,8 +78,7 @@ def test_tmgr_rp_tmgr():
                   pending_queue=['pendingq-1'],
                   completed_queue=['completedq-1'],
                   rmgr=rmgr,
-                  mq_hostname=hostname,
-                  port=port)
+                  rmq_conn_params=rmq_conn_params)
 
     tmgr.start_manager()
 

--- a/tests/test_component/test_tmgr_2.py
+++ b/tests/test_component/test_tmgr_2.py
@@ -68,7 +68,7 @@ def test_tmgr_rp_tmgr():
                 "db_cleanup"     : False}
     rmgr_id  = ru.generate_id('test', ru.ID_UNIQUE)
     rmgr     = RPRmgr(resource_desc=res_dict, sid=rmgr_id, rts_config=config)
-    mq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     rmgr._validate_resource_desc()
     rmgr._populate()

--- a/tests/test_component/test_tmgr_advance.py
+++ b/tests/test_component/test_tmgr_advance.py
@@ -19,18 +19,18 @@ def func(obj, obj_type, new_state, queue1):
     hostname = os.environ.get('RMQ_HOSTNAME', 'localhost')
     port = int(os.environ.get('RMQ_PORT', 5672))
 
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
+
     sid  = 'test.0013'
     rmgr = BaseRmgr({}, sid, None, {})
     tmgr = BaseTmgr(sid=sid,
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
-    mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                      host=hostname, port=port))
+    mq_connection = pika.BlockingConnection(rmq_conn_params)
     mq_channel = mq_connection.channel()
 
     tmgr._advance(obj, obj_type, new_state, mq_channel, queue1)

--- a/tests/test_component/test_wfp.py
+++ b/tests/test_component/test_wfp.py
@@ -22,18 +22,17 @@ settings.load_profile("travis")
 # ------------------------------------------------------------------------------
 #
 @given(s=st.characters(),
-       i=st.integers().filter(lambda x: isinstance(x,int)),
        b=st.booleans(),
        l=st.lists(st.characters()))
-def test_wfp_initialization(s, i, b, l):
+def test_wfp_initialization(s, b, l):
 
     p  = Pipeline()
-    st = Stage()
+    stage = Stage()
     t  = Task()
 
     t.executable = '/bin/date'
-    st.add_tasks(t)
-    p.add_stages(st)
+    stage.add_tasks(t)
+    p.add_stages(stage)
     rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     wfp = WFprocessor(sid='rp.session.local.0000',
@@ -193,9 +192,6 @@ def test_wfp_dequeue():
     for t in p.stages[0].tasks:
         assert t.state == states.INITIAL
 
-    p.state           == states.SCHEDULED
-    p.stages[0].state == states.SCHEDULING
-
     for t in p.stages[0].tasks:
         t.state = states.COMPLETED
 
@@ -312,9 +308,6 @@ def test_wfp_workflow_incomplete():
                       resubmit_failed=False)
 
     wfp.initialize_workflow()
-
-    p.state           == states.SCHEDULED
-    p.stages[0].state == states.SCHEDULING
 
     for t in p.stages[0].tasks:
         t.state = states.COMPLETED

--- a/tests/test_component/test_wfp.py
+++ b/tests/test_component/test_wfp.py
@@ -34,7 +34,7 @@ def test_wfp_initialization(s, i, b, l):
     t.executable = '/bin/date'
     st.add_tasks(t)
     p.add_stages(st)
-    mq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     wfp = WFprocessor(sid='rp.session.local.0000',
                       workflow=set([p]),
@@ -71,7 +71,7 @@ def test_wfp_initialize_workflow():
     t.executable = '/bin/date'
     s.add_tasks(t)
     p.add_stages(s)
-    mq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     wfp = WFprocessor(sid='test',
                       workflow=[p],

--- a/tests/test_component/test_wfp.py
+++ b/tests/test_component/test_wfp.py
@@ -34,21 +34,20 @@ def test_wfp_initialization(s, i, b, l):
     t.executable = '/bin/date'
     st.add_tasks(t)
     p.add_stages(st)
+    mq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     wfp = WFprocessor(sid='rp.session.local.0000',
                       workflow=set([p]),
                       pending_queue=['pending'],
                       completed_queue=['completed'],
-                      mq_hostname=hostname,
-                      port=port,
+                      rmq_conn_params=rmq_conn_params,
                       resubmit_failed=True)
 
     assert len(wfp._uid.split('.')) == 2
     assert 'wfprocessor'            == wfp._uid.split('.')[0]
     assert wfp._pending_queue       == ['pending']
     assert wfp._completed_queue     == ['completed']
-    assert wfp._hostname            == hostname
-    assert wfp._port                == port
+    assert wfp._rmq_conn_params     == rmq_conn_params
     assert wfp._wfp_process         is None
     assert wfp._workflow            == set([p])
 
@@ -57,8 +56,7 @@ def test_wfp_initialization(s, i, b, l):
                           workflow=set([p]),
                           pending_queue=l,
                           completed_queue=l,
-                          mq_hostname=s,
-                          port=i,
+                          rmq_conn_params=rmq_conn_params,
                           resubmit_failed=b)
 
 
@@ -73,13 +71,13 @@ def test_wfp_initialize_workflow():
     t.executable = '/bin/date'
     s.add_tasks(t)
     p.add_stages(s)
+    mq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
 
     wfp = WFprocessor(sid='test',
                       workflow=[p],
                       pending_queue=list(),
                       completed_queue=list(),
-                      mq_hostname=hostname,
-                      port=port,
+                      rmq_conn_params=rmq_conn_params,
                       resubmit_failed=False)
 
     wfp.initialize_workflow()
@@ -124,8 +122,7 @@ def test_wfp_enqueue():
                       workflow=[p],
                       pending_queue=amgr._pending_queue,
                       completed_queue=amgr._completed_queue,
-                      mq_hostname=amgr._hostname,
-                      port=amgr._port,
+                      rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
 
     wfp.initialize_workflow()
@@ -185,8 +182,7 @@ def test_wfp_dequeue():
                       workflow=[p],
                       pending_queue=amgr._pending_queue,
                       completed_queue=amgr._completed_queue,
-                      mq_hostname=amgr._hostname,
-                      port=amgr._port,
+                      rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
 
     wfp.initialize_workflow()
@@ -247,8 +243,7 @@ def test_wfp_start_processor():
                       workflow=[p],
                       pending_queue=amgr._pending_queue,
                       completed_queue=amgr._completed_queue,
-                      mq_hostname=amgr._hostname,
-                      port=amgr._port,
+                      rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
 
     wfp.start_processor()
@@ -281,8 +276,7 @@ def test_wfp_terminate_processor():
                       workflow=[p],
                       pending_queue=amgr._pending_queue,
                       completed_queue=amgr._completed_queue,
-                      mq_hostname=amgr._hostname,
-                      port=amgr._port,
+                      rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
 
     wfp.start_processor()
@@ -314,8 +308,7 @@ def test_wfp_workflow_incomplete():
                       workflow=[p],
                       pending_queue=amgr._pending_queue,
                       completed_queue=amgr._completed_queue,
-                      mq_hostname=amgr._hostname,
-                      port=amgr._port,
+                      rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
 
     wfp.initialize_workflow()
@@ -365,8 +358,7 @@ def test_wfp_check_processor():
                       workflow=[p],
                       pending_queue=amgr._pending_queue,
                       completed_queue=amgr._completed_queue,
-                      mq_hostname=amgr._hostname,
-                      port=amgr._port,
+                      rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
 
     wfp.start_processor()

--- a/tests/test_integration/test_integration_local.py
+++ b/tests/test_integration/test_integration_local.py
@@ -1,16 +1,16 @@
 from radical.entk import Pipeline, Stage, Task, AppManager
-import pytest
-from radical.entk.exceptions import *
 import os
 
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
+
 
 def test_integration_local():
 
     """
     **Purpose**: Run an EnTK application on localhost
     """
+
 
     def create_single_task():
 
@@ -23,9 +23,9 @@ def test_integration_local():
 
         return t1
 
+
     p1 = Pipeline()
     p1.name = 'p1'
-
     s = Stage()
     s.name = 's1'
     s.tasks = create_single_task()

--- a/tests/test_integration/test_integration_local.py
+++ b/tests/test_integration/test_integration_local.py
@@ -5,7 +5,6 @@ import os
 
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
-MLAB = os.environ.get('RADICAL_PILOT_DBURL')
 
 def test_integration_local():
 
@@ -43,7 +42,6 @@ def test_integration_local():
 
     }
 
-    os.environ['RADICAL_PILOT_DBURL'] = MLAB
 
     appman = AppManager(hostname=hostname, port=port)
     appman.resource_desc = res_dict

--- a/tests/test_integration/test_post_exec.py
+++ b/tests/test_integration/test_post_exec.py
@@ -1,10 +1,9 @@
 from radical.entk import Pipeline, Stage, Task, AppManager
-import pytest
-from radical.entk.exceptions import *
 import os
 
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
+
 
 def create_single_task():
 
@@ -17,19 +16,22 @@ def create_single_task():
 
     return t1
 
+
 NUM_TASKS = 2
 MAX_STAGES = 5
 CUR_STAGE = 1
 
+
 def condition():
 
     global CUR_STAGE, MAX_STAGES
-    
+
     if CUR_STAGE < MAX_STAGES:
         CUR_STAGE += 1
         on_true()
 
     on_false()
+
 
 def on_true():
 
@@ -38,7 +40,7 @@ def on_true():
     NUM_TASKS *= 2
 
     s = Stage()
-    s.name = 's%s'%CUR_STAGE
+    s.name = 's%s' % CUR_STAGE
 
     for t in range(NUM_TASKS):
         s.add_tasks(create_single_task())
@@ -54,10 +56,11 @@ def on_false():
 
 p1 = Pipeline()
 
+
 def test_stage_post_exec():
 
     global p1
-    
+
     p1.name = 'p1'
 
     s = Stage()

--- a/tests/test_integration/test_post_exec.py
+++ b/tests/test_integration/test_post_exec.py
@@ -5,7 +5,6 @@ import os
 
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
-MLAB = os.environ.get('RADICAL_PILOT_DBURL')
 
 def create_single_task():
 
@@ -78,7 +77,6 @@ def test_stage_post_exec():
             'cpus': 1,
     }
 
-    os.environ['RADICAL_PILOT_DBURL'] = MLAB
     appman = AppManager(rts='radical.pilot', hostname=hostname, port=port)
     appman.resource_desc = res_dict
     appman.workflow = [p1]

--- a/tests/test_integration/test_post_exec.py
+++ b/tests/test_integration/test_post_exec.py
@@ -5,68 +5,65 @@ hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
 
 
-def create_single_task():
-
-    t1 = Task()
-    t1.name = 'simulation'
-    t1.executable = '/bin/echo'
-    t1.arguments = ['hello']
-    t1.copy_input_data = []
-    t1.copy_output_data = []
-
-    return t1
-
-
-NUM_TASKS = 2
-MAX_STAGES = 5
-CUR_STAGE = 1
-
-
-def condition():
-
-    global CUR_STAGE, MAX_STAGES
-
-    if CUR_STAGE < MAX_STAGES:
-        CUR_STAGE += 1
-        on_true()
-
-    on_false()
-
-
-def on_true():
-
-    global NUM_TASKS, CUR_STAGE
-
-    NUM_TASKS *= 2
-
-    s = Stage()
-    s.name = 's%s' % CUR_STAGE
-
-    for t in range(NUM_TASKS):
-        s.add_tasks(create_single_task())
-
-    s.post_exec = condition
-
-    p1.add_stages(s)
-
-
-def on_false():
-    pass
-
-
-p1 = Pipeline()
-
-
 def test_stage_post_exec():
 
-    global p1
-
+    p1 = Pipeline()
     p1.name = 'p1'
 
     s = Stage()
     s.name = 's1'
 
-    for t in range(NUM_TASKS):
+
+    def create_single_task():
+
+        t1 = Task()
+        t1.name = 'simulation'
+        t1.executable = '/bin/echo'
+        t1.arguments = ['hello']
+        t1.copy_input_data = []
+        t1.copy_output_data = []
+
+        return t1
+
+
+    NUM_TASKS = 2
+    MAX_STAGES = 5
+    CUR_STAGE = 1
+
+
+    def condition():
+
+        nonlocal CUR_STAGE, MAX_STAGES
+
+        if CUR_STAGE < MAX_STAGES:
+            CUR_STAGE += 1
+            on_true()
+
+        on_false()
+
+
+    def on_true():
+
+        nonlocal NUM_TASKS, CUR_STAGE, p1
+
+        NUM_TASKS *= 2
+
+        s = Stage()
+        s.name = 's%s' % CUR_STAGE
+
+        for _ in range(NUM_TASKS):
+            s.add_tasks(create_single_task())
+
+        s.post_exec = condition
+
+        p1.add_stages(s)
+
+
+    def on_false():
+        pass
+
+
+    for _ in range(NUM_TASKS):
         s.add_tasks(create_single_task())
 
     s.post_exec = condition

--- a/tests/test_integration/test_shared_data.py
+++ b/tests/test_integration/test_shared_data.py
@@ -1,7 +1,6 @@
 from radical.entk import Pipeline, Stage, Task, AppManager
 import os
 from glob import glob
-import shutil
 
 # ------------------------------------------------------------------------------
 # Set default verbosity
@@ -28,7 +27,7 @@ def generate_pipeline():
     t1.arguments = ['file1.txt','file2.txt']
     t1.stdout = 'output.txt'
     t1.copy_input_data = ['$SHARED/file1.txt', '$SHARED/file2.txt']
-    t1.download_output_data = ['output.txt > %s/output.txt' %cur_dir]
+    t1.download_output_data = ['output.txt > %s/output.txt' % cur_dir]
 
     # Add the Task to the Stage
     s1.add_tasks(t1)
@@ -38,13 +37,14 @@ def generate_pipeline():
 
     return p
 
+
 def test_shared_data():
 
-    for f in glob('%s/file*.txt' %cur_dir):
+    for f in glob('%s/file*.txt' % cur_dir):
         os.remove(f)
 
-    os.system('echo "Hello" > %s/file1.txt' %cur_dir)
-    os.system('echo "World" > %s/file2.txt' %cur_dir)
+    os.system('echo "Hello" > %s/file1.txt' % cur_dir)
+    os.system('echo "World" > %s/file2.txt' % cur_dir)
 
 
     # Create a dictionary describe four mandatory keys:
@@ -63,7 +63,7 @@ def test_shared_data():
 
     # Assign resource manager to the Application Manager
     appman.resource_desc = res_dict
-    appman.shared_data = ['%s/file1.txt' %cur_dir, '%s/file2.txt' %cur_dir]
+    appman.shared_data = ['%s/file1.txt' % cur_dir, '%s/file2.txt' % cur_dir]
 
     p = generate_pipeline()
 
@@ -73,9 +73,9 @@ def test_shared_data():
     # Run the Application Manager
     appman.run()
 
-    with open('%s/output.txt' %cur_dir, 'r') as fp:
+    with open('%s/output.txt' % cur_dir, 'r') as fp:
         assert [d.strip() for d in fp.readlines()] == ['Hello', 'World']
 
-    os.remove('%s/file1.txt' %cur_dir)
-    os.remove('%s/file2.txt' %cur_dir)
-    os.remove('%s/output.txt' %cur_dir)
+    os.remove('%s/file1.txt' % cur_dir)
+    os.remove('%s/file2.txt' % cur_dir)
+    os.remove('%s/output.txt' % cur_dir)

--- a/tests/test_integration/test_shared_data.py
+++ b/tests/test_integration/test_shared_data.py
@@ -12,7 +12,6 @@ if not os.environ.get('RADICAL_ENTK_VERBOSE'):
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
 cur_dir = os.path.dirname(os.path.abspath(__file__))
-MLAB = os.environ.get('RADICAL_PILOT_DBURL')
 
 
 def generate_pipeline():
@@ -58,7 +57,6 @@ def test_shared_data():
             'cpus': 1
     }
 
-    os.environ['RADICAL_PILOT_DBURL'] = MLAB
 
     # Create Application Manager
     appman = AppManager(hostname=hostname, port=port)

--- a/tests/test_issues/test_issue_199.py
+++ b/tests/test_issues/test_issue_199.py
@@ -9,7 +9,6 @@ if not os.environ.get('RADICAL_ENTK_VERBOSE'):
 
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
-MLAB = os.environ.get('RADICAL_PILOT_DBURL')
 
 def generate_pipeline():
 
@@ -45,7 +44,6 @@ def test_issue_199():
             'cpus': 1
     }
 
-    os.environ['RADICAL_PILOT_DBURL'] = MLAB
 
     # Create Application Manager
     appman = AppManager(hostname=hostname, port=port)

--- a/tests/test_issues/test_issue_199.py
+++ b/tests/test_issues/test_issue_199.py
@@ -10,6 +10,7 @@ if not os.environ.get('RADICAL_ENTK_VERBOSE'):
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
 
+
 def generate_pipeline():
 
     # Create a Pipeline object
@@ -30,6 +31,7 @@ def generate_pipeline():
     p.add_stages(s1)
 
     return p
+
 
 def test_issue_199():
 

--- a/tests/test_issues/test_issue_214.py
+++ b/tests/test_issues/test_issue_214.py
@@ -42,7 +42,7 @@ def test_issue_214():
     res_dict = {
 
             'resource': 'local.localhost',
-            'walltime': (int(sleep)/60)+5,
+            'walltime': (int(sleep)//60)+5,
             'cpus': 1
     }
 

--- a/tests/test_issues/test_issue_214.py
+++ b/tests/test_issues/test_issue_214.py
@@ -11,7 +11,6 @@ if not os.environ.get('RADICAL_ENTK_VERBOSE'):
 hostname = os.environ.get('RMQ_HOSTNAME','localhost')
 port = int(os.environ.get('RMQ_PORT',5672))
 sleep = os.environ.get('TEST_214_SLEEP_DURATION',300)
-MLAB = os.environ.get('RADICAL_PILOT_DBURL')
 
 
 def generate_pipeline():
@@ -47,7 +46,6 @@ def test_issue_214():
             'cpus': 1
     }
 
-    os.environ['RADICAL_PILOT_DBURL'] = MLAB
 
     # Create Application Manager
     appman = AppManager(hostname=hostname, port=port)

--- a/tests/test_issues/test_issue_214.py
+++ b/tests/test_issues/test_issue_214.py
@@ -34,6 +34,7 @@ def generate_pipeline():
 
     return p
 
+
 def test_issue_214():
 
     # Create a dictionary describe four mandatory keys:
@@ -42,7 +43,7 @@ def test_issue_214():
     res_dict = {
 
             'resource': 'local.localhost',
-            'walltime': (int(sleep)//60)+5,
+            'walltime': (int(sleep) // 60) + 5,
             'cpus': 1
     }
 

--- a/tests/test_utils/sample_data/expected_desc_write_session.json
+++ b/tests/test_utils/sample_data/expected_desc_write_session.json
@@ -21,9 +21,9 @@
                 "2": "SCHEDULING",
                 "3": "SUSPENDED",
                 "10": [
+                    "DONE",
                     "FAILED",
-                    "CANCELED",
-                    "DONE"
+                    "CANCELED"
                 ]
             }
         },
@@ -42,9 +42,9 @@
                 "2": "SCHEDULING",
                 "4": "SCHEDULED",
                 "10": [
+                    "DONE",
                     "FAILED",
-                    "CANCELED",
-                    "DONE"
+                    "CANCELED"
                 ]
             }
         },
@@ -63,9 +63,9 @@
             "state_values": {
                 "1": "DESCRIBED",
                 "10": [
+                    "DONE",
                     "FAILED",
-                    "CANCELED",
-                    "DONE"
+                    "CANCELED"
                 ],
                 "2": "SCHEDULING",
                 "4": "SCHEDULED",

--- a/tests/test_utils/test_prof_utils.py
+++ b/tests/test_utils/test_prof_utils.py
@@ -11,7 +11,7 @@ from radical.entk.execman.rp         import TaskManager
 from radical.entk.utils              import get_session_profile
 from radical.entk.utils              import get_session_description
 from radical.entk.utils              import write_session_description
-from radical.entk.utils              import write_workflow
+from radical.entk.utils              import write_workflows
 
 hostname =     os.environ.get('RMQ_HOSTNAME', 'localhost')
 port     = int(os.environ.get('RMQ_PORT', 5672))
@@ -128,7 +128,7 @@ def generate_pipeline(nid):
 
 # ------------------------------------------------------------------------------
 #
-def test_write_workflow():
+def test_write_workflows():
 
     # --------------------------------------------------------------------------
     def check_stack(stack):
@@ -186,7 +186,7 @@ def test_write_workflow():
         # ----------------------------------------------------------------------
         # check json output, with defaut and custom fname
         for fname in [None, 'wf.json']:
-            write_workflow(amgr.workflows, 'test', fname=fname)
+            write_workflows(amgr.workflows, 'test', fname=fname)
 
             if not fname: fname = 'entk_workflow.json'
             data = ru.read_json('test/%s' % fname)
@@ -201,7 +201,7 @@ def test_write_workflow():
 
         # ----------------------------------------------------------------------
         # check with data return
-        data = write_workflow(amgr.workflows, 'test', fwrite=False)
+        data = write_workflows(amgr.workflows, 'test', fwrite=False)
 
         check_stack(data['stack'])
         check_wf(data['workflows'][0], check)
@@ -221,7 +221,7 @@ def test_write_workflow():
         amgr._wfp.initialize_workflow()
         check = amgr.workflows
 
-        data = write_workflow(amgr.workflows, 'test', fwrite=False)
+        data = write_workflows(amgr.workflows, 'test', fwrite=False)
 
         check_stack(data['stack'])
         check_wf(data['workflows'][0], check[0])
@@ -243,7 +243,7 @@ if __name__ == '__main__':
     test_get_session_profile()
     test_write_session_description()
     test_get_session_description()
-    test_write_workflow()
+    test_write_workflows()
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_utils/test_prof_utils.py
+++ b/tests/test_utils/test_prof_utils.py
@@ -143,7 +143,6 @@ def test_write_workflows():
         assert 'radical.pilot' in stack['radical']
         assert 'radical.entk'  in stack['radical']
 
-
     # --------------------------------------------------------------------------
     def check_wf(wf, check):
 

--- a/tests/test_utils/test_prof_utils.py
+++ b/tests/test_utils/test_prof_utils.py
@@ -43,7 +43,7 @@ def test_write_session_description():
 
     amgr = AppManager(hostname=hostname, port=port)
     amgr.resource_desc = {'resource' : 'xsede.stampede',
-                          'walltime' : 60,
+                          'walltime' : 59,
                           'cpus'     : 128,
                           'gpus'     : 64,
                           'project'  : 'xyz',
@@ -56,18 +56,16 @@ def test_write_session_description():
                             workflow=amgr._workflow,
                             pending_queue=amgr._pending_queue,
                             completed_queue=amgr._completed_queue,
-                            mq_hostname=amgr._hostname,
-                            port=amgr._port,
-                            resubmit_failed=amgr._resubmit_failed)
+                            resubmit_failed=amgr._resubmit_failed,
+                            rmq_conn_params=amgr._rmq_conn_params)
     amgr._wfp.initialize_workflow()
     amgr._workflow = amgr._wfp.workflow
 
     amgr._task_manager = TaskManager(sid=amgr._sid,
                                      pending_queue=amgr._pending_queue,
                                      completed_queue=amgr._completed_queue,
-                                     mq_hostname=amgr._hostname,
                                      rmgr=amgr._rmgr,
-                                     port=amgr._port
+                                     rmq_conn_params=amgr._rmq_conn_params
                                      )
 
     write_session_description(amgr)
@@ -176,9 +174,8 @@ def test_write_workflows():
                                     workflow=amgr._workflow,
                                     pending_queue=amgr._pending_queue,
                                     completed_queue=amgr._completed_queue,
-                                    mq_hostname=amgr._hostname,
-                                    port=amgr._port,
-                                    resubmit_failed=amgr._resubmit_failed)
+                                    resubmit_failed=amgr._resubmit_failed,
+                                    rmq_conn_params=amgr._rmq_conn_params)
 
         amgr._wfp.initialize_workflow()
         check = amgr.workflow
@@ -215,9 +212,8 @@ def test_write_workflows():
                                     workflow=amgr._workflow,
                                     pending_queue=amgr._pending_queue,
                                     completed_queue=amgr._completed_queue,
-                                    mq_hostname=amgr._hostname,
-                                    port=amgr._port,
-                                    resubmit_failed=amgr._resubmit_failed)
+                                    resubmit_failed=amgr._resubmit_failed,
+                                    rmq_conn_params=amgr._rmq_conn_params)
         amgr._wfp.initialize_workflow()
         check = amgr.workflows
 

--- a/tests/test_utils/test_sync_with_master.py
+++ b/tests/test_utils/test_sync_with_master.py
@@ -16,8 +16,8 @@ def syncer(obj, obj_type, queue1):
     hostname = os.environ.get('RMQ_HOSTNAME', 'localhost')
     port = int(os.environ.get('RMQ_PORT', 5672))
 
-    mq_connection = pika.BlockingConnection(pika.ConnectionParameters(
-                                                      host=hostname, port=port))
+    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
+    mq_connection = pika.BlockingConnection(rmq_conn_params)
     mq_channel = mq_connection.channel()
 
     sid = 'test.0015'
@@ -26,8 +26,7 @@ def syncer(obj, obj_type, queue1):
                     pending_queue=['pending-1'],
                     completed_queue=['completed-1'],
                     rmgr=rmgr,
-                    mq_hostname=hostname,
-                    port=port,
+                    rmq_conn_params=rmq_conn_params,
                     rts=None)
 
     tmgr._sync_with_master(obj, obj_type, mq_channel, queue1)


### PR DESCRIPTION
TOC updated:
- installation
- user guide
- examples/getting started



Sections eliminated are:
- mongodb installation
- mongodb env configuration with mlab
   -  no env set leads to a default value to be loaded
- rabbitmq installation
- rabbitmq configuration
    - two.radical is exposed to use