### PR TITLE
early assignment of UIDs

### DIFF
--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -91,8 +91,7 @@ class AppManager(object):
         # Create an uid + logger + profiles for AppManager, under the sid
         # namespace
 
-        self._uid    = ru.generate_id('appmanager.%(item_counter)04d',
-                                      ru.ID_CUSTOM, ns=self._sid)
+        self._uid = ru.generate_id('appmanager.%(counter)04d', ru.ID_CUSTOM)
 
         path = os.getcwd() + '/' + self._sid
         name = 'radical.entk.%s' % self._uid

--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -616,7 +616,6 @@ class AppManager(object):
             # start the threads again.
             self._wfp.terminate_processor()
             self._wfp._workflow = self._workflow
-            self._wfp.initialize_workflow()
             self._wfp.start_processor()
             return
 
@@ -629,7 +628,6 @@ class AppManager(object):
                                 completed_queue=self._completed_queue,
                                 resubmit_failed=self._resubmit_failed,
                                 rmq_conn_params=self._rmq_conn_params)
-        self._wfp.initialize_workflow()
         self._prof.prof('wfp_create_stop', uid=self._uid)
 
         # Start synchronizer thread AM OK

--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -149,7 +149,6 @@ class WFprocessor(object):
                     # TODO: Move parent uid, name assignment to assign_uid()
                     exec_stage.parent_pipeline['uid']  = pipe.uid
                     exec_stage.parent_pipeline['name'] = pipe.name
-                    exec_stage._assign_uid(self._sid)
 
                 # If its a new stage, update its state
                 if exec_stage.state == states.INITIAL:
@@ -486,28 +485,6 @@ class WFprocessor(object):
     # --------------------------------------------------------------------------
     #
     # Public Methods
-    #
-    def initialize_workflow(self):
-        """
-        **Purpose**: Initialize the PST of the workflow with a uid and type
-        checks
-        """
-
-        try:
-
-            self._prof.prof('wf_init_start', uid=self._uid)
-
-            for p in self._workflow:
-                p._assign_uid(self._sid)
-
-            self._prof.prof('wf_init_stop', uid=self._uid)
-
-        except Exception:
-            self._logger.exception('Fatal error when initializing workflow')
-            raise
-
-
-    # --------------------------------------------------------------------------
     #
     def start_processor(self):
         """

--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -59,8 +59,7 @@ class WFprocessor(object):
 
         # Create logger and profiler at their specific locations using the sid
         self._path = os.getcwd() + '/' + self._sid
-        self._uid  = ru.generate_id('wfprocessor.%(item_counter)04d',
-                                    ru.ID_CUSTOM, ns=self._sid)
+        self._uid  = ru.generate_id('wfprocessor.%(counter)04d', ru.ID_CUSTOM)
 
         name = 'radical.entk.%s' % self._uid
         self._logger = ru.Logger  (name, path=self._path)

--- a/src/radical/entk/execman/base/resource_manager.py
+++ b/src/radical/entk/execman/base/resource_manager.py
@@ -52,8 +52,8 @@ class Base_ResourceManager(object):
         self._validated     = False
 
         # Utility parameters
-        self._uid = ru.generate_id('resource_manager.%(item_counter)04d',
-                                   ru.ID_CUSTOM, ns=self._sid)
+        self._uid = ru.generate_id('resource_manager.%(counter)04d',
+                                   ru.ID_CUSTOM)
         self._path = os.getcwd() + '/' + self._sid
 
         name = 'radical.entk.%s' % self._uid

--- a/src/radical/entk/execman/base/task_manager.py
+++ b/src/radical/entk/execman/base/task_manager.py
@@ -76,8 +76,7 @@ class Base_TaskManager(object):
         self._rmq_conn_params = rmq_conn_params
 
         # Utility parameters
-        self._uid  = ru.generate_id('task_manager.%(item_counter)04d',
-                                    ru.ID_CUSTOM, ns=self._sid)
+        self._uid  = ru.generate_id('task_manager.%(counter)04d', ru.ID_CUSTOM)
         self._path = os.getcwd() + '/' + self._sid
 
         name = 'radical.entk.%s' % self._uid

--- a/src/radical/entk/pipeline/pipeline.py
+++ b/src/radical/entk/pipeline/pipeline.py
@@ -9,15 +9,16 @@ from collections import Iterable
 class Pipeline(object):
 
     """
-    A pipeline represents a collection of objects that have a linear temporal execution order.
-    In this case, a pipeline consists of multiple 'Stage' objects. Each ```Stage_i``` can execute only
-    after all stages up to ```Stage_(i-1)``` have completed execution.
+    A pipeline represents a collection of objects that have a linear temporal
+    execution order.  In this case, a pipeline consists of multiple 'Stage'
+    objects. Each ```Stage_i``` can execute only after all stages up to
+    ```Stage_(i-1)``` have completed execution.
 
     """
 
     def __init__(self):
 
-        self._uid = None
+        self._uid  = ru.generate_id('pipeline.%(item_counter)04d', ru.ID_CUSTOM)
         self._name = None
 
         self._stages = list()
@@ -204,6 +205,14 @@ class Pipeline(object):
         if self._cur_stage == 0:
             self._cur_stage = 1
 
+        for stage in stages:
+            stage.parent_pipeline['uid']  = self._uid
+            stage.parent_pipeline['name'] = self._name
+
+            for task in stage.tasks:
+                task.parent_pipeline['uid']  = self._uid
+                task.parent_pipeline['name'] = self._name
+
 
     def to_dict(self):
         """
@@ -382,27 +391,6 @@ class Pipeline(object):
         for stage in self._stages:
             stage._validate()
 
-    def _assign_uid(self, sid):
-        """
-        Purpose: Assign a uid to the current object based on the sid passed. Pass the current uid to children of
-        current object
-        """
-        self._uid = ru.generate_id('pipeline.%(item_counter)04d',
-                                   ru.ID_CUSTOM, ns=sid)
-        for stage in self._stages:
-            stage._assign_uid(sid)
 
-        self._pass_uid()
+# ------------------------------------------------------------------------------
 
-    def _pass_uid(self):
-        """
-        Purpose: Pass current Pipeline's uid to all Stages.
-
-        :argument: List of Stage objects (optional)
-        """
-
-        for stage in self._stages:
-            stage.parent_pipeline['uid'] = self._uid
-            stage.parent_pipeline['name'] = self._name
-            stage._pass_uid()
-    # ------------------------------------------------------------------------------------------------------------------

--- a/src/radical/entk/pipeline/pipeline.py
+++ b/src/radical/entk/pipeline/pipeline.py
@@ -18,7 +18,7 @@ class Pipeline(object):
 
     def __init__(self):
 
-        self._uid  = ru.generate_id('pipeline.%(item_counter)04d', ru.ID_CUSTOM)
+        self._uid  = ru.generate_id('pipeline.%(counter)04d', ru.ID_CUSTOM)
         self._name = None
 
         self._stages = list()

--- a/src/radical/entk/stage/stage.py
+++ b/src/radical/entk/stage/stage.py
@@ -14,7 +14,7 @@ class Stage(object):
 
     def __init__(self):
 
-        self._uid = ru.generate_id('stage.%(item_counter)04d', ru.ID_CUSTOM)
+        self._uid = ru.generate_id('stage.%(counter)04d', ru.ID_CUSTOM)
         self._name = None
 
         self._tasks = set()

--- a/src/radical/entk/stage/stage.py
+++ b/src/radical/entk/stage/stage.py
@@ -7,13 +7,14 @@ from collections import Iterable
 
 class Stage(object):
     """
-    A stage represents a collection of objects that have no relative order of execution. In this case, a
-    stage consists of a set of 'Task' objects. All tasks of the same stage may execute concurrently.
+    A stage represents a collection of objects that have no relative order of
+    execution. In this case, a stage consists of a set of 'Task' objects. All
+    tasks of the same stage may execute concurrently.
     """
 
     def __init__(self):
 
-        self._uid = None
+        self._uid = ru.generate_id('stage.%(item_counter)04d', ru.ID_CUSTOM)
         self._name = None
 
         self._tasks = set()
@@ -191,9 +192,9 @@ class Stage(object):
         self._post_exec = value
 
 
-    # ------------------------------------------------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Public methods
-    # ------------------------------------------------------------------------------------------------------------------
+    #
     def add_tasks(self, value):
         """
         Adds tasks to the existing set of tasks of the Stage
@@ -203,6 +204,14 @@ class Stage(object):
         tasks = self._validate_entities(value)
         self._tasks.update(tasks)
         self._task_count = len(self._tasks)
+
+        for task in self._tasks:
+            task.parent_stage['uid']  = self._uid
+            task.parent_stage['name'] = self._name
+
+            task.parent_pipeline['uid']  = self.parent_pipeline['uid']
+            task.parent_pipeline['name'] = self.parent_pipeline['name']
+
 
     def to_dict(self):
         """
@@ -344,29 +353,6 @@ class Stage(object):
         for task in self._tasks:
             task._validate()
 
-    def _assign_uid(self, sid):
-        """
-        Purpose: Assign a uid to the current object based on the sid passed. Pass the current uid to children of
-        current object
-        """
-        self._uid = ru.generate_id('stage.%(item_counter)04d',
-                                   ru.ID_CUSTOM, ns=sid)
-        for task in self._tasks:
-            task._assign_uid(sid)
 
-        self._pass_uid()
+# ------------------------------------------------------------------------------
 
-    def _pass_uid(self):
-        """
-        Purpose: Assign the parent Stage and the parent Pipeline to all the tasks of the current stage.
-
-        :arguments: set of Tasks (optional)
-        :return: list of updated Tasks
-        """
-
-        for task in self._tasks:
-            task.parent_stage['uid'] = self._uid
-            task.parent_stage['name'] = self._name
-            task.parent_pipeline['uid'] = self._p_pipeline['uid']
-            task.parent_pipeline['name'] = self._p_pipeline['name']
-    # ------------------------------------------------------------------------------------------------------------------

--- a/src/radical/entk/task/task.py
+++ b/src/radical/entk/task/task.py
@@ -27,7 +27,7 @@ class Task(object):
     #
     def __init__(self, from_dict=None):
 
-        self._uid   = ru.generate_id('task.%(item_counter)04d', ru.ID_CUSTOM)
+        self._uid   = ru.generate_id('task.%(counter)04d', ru.ID_CUSTOM)
         self._name  = ""
         self._state = res.INITIAL
 

--- a/src/radical/entk/task/task.py
+++ b/src/radical/entk/task/task.py
@@ -27,9 +27,9 @@ class Task(object):
     #
     def __init__(self, from_dict=None):
 
-        self._uid        = None
-        self._name       = ""
-        self._state      = res.INITIAL
+        self._uid   = ru.generate_id('task.%(item_counter)04d', ru.ID_CUSTOM)
+        self._name  = ""
+        self._state = res.INITIAL
 
         # Attributes necessary for execution
         self._pre_exec   = list()
@@ -929,17 +929,6 @@ class Task(object):
             if k not in ['uid', 'name', 'state']:
                 if v is not None:
                     setattr(self, k, v)
-
-
-    # --------------------------------------------------------------------------
-    #
-    def _assign_uid(self, sid):
-        '''
-        Purpose: Assign uid to the current object based on the session ID passed
-        '''
-
-        self.uid = ru.generate_id('task.%(item_counter)04d',
-                                  ru.ID_CUSTOM, ns=sid)
 
 
     # --------------------------------------------------------------------------

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -429,7 +429,6 @@ def test_amgr_synchronizer():
         s.add_tasks(t)
 
     p.add_stages(s)
-    p._assign_uid(amgr._sid)
     p._validate()
 
     amgr.workflow = [p]

--- a/tests/test_component/test_pipeline.py
+++ b/tests/test_component/test_pipeline.py
@@ -260,7 +260,6 @@ def test_pipeline_validate():
 #
 def test_pipeline_assign_uid():
 
-    p = Pipeline()
     try:
         import glob
         import shutil
@@ -271,7 +270,7 @@ def test_pipeline_assign_uid():
             shutil.rmtree(f)
     except:
         pass
-    p._assign_uid('test')
+    p = Pipeline()
     assert p.uid == 'pipeline.0000'
 
 

--- a/tests/test_component/test_stage.py
+++ b/tests/test_component/test_stage.py
@@ -295,7 +295,6 @@ def test_stage_validate():
 #
 def test_stage_assign_uid():
 
-    s = Stage()
     try:
         import glob
         import shutil
@@ -306,7 +305,7 @@ def test_stage_assign_uid():
             shutil.rmtree(f)
     except:
         pass
-    s._assign_uid('test')
+    s = Stage()
     assert s.uid == 'stage.0000'
 
 

--- a/tests/test_component/test_task.py
+++ b/tests/test_component/test_task.py
@@ -418,7 +418,6 @@ def test_task_from_dict():
 #
 def test_task_assign_uid():
 
-    t = Task()
     try:
         home   = os.environ.get('HOME', '/home')
         folder = glob.glob('%s/.radical/utils/test*' % home)
@@ -428,7 +427,7 @@ def test_task_assign_uid():
     except:
         pass
 
-    t._assign_uid('test')
+    t = Task()
     assert t.uid == 'task.0000'
 
 

--- a/tests/test_component/test_wfp.py
+++ b/tests/test_component/test_wfp.py
@@ -61,34 +61,6 @@ def test_wfp_initialization(s, b, l):
 
 # ------------------------------------------------------------------------------
 #
-def test_wfp_initialize_workflow():
-
-    p = Pipeline()
-    s = Stage()
-    t = Task()
-
-    t.executable = '/bin/date'
-    s.add_tasks(t)
-    p.add_stages(s)
-    rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port)
-
-    wfp = WFprocessor(sid='test',
-                      workflow=[p],
-                      pending_queue=list(),
-                      completed_queue=list(),
-                      rmq_conn_params=rmq_conn_params,
-                      resubmit_failed=False)
-
-    wfp.initialize_workflow()
-    assert p.uid           is not None
-    assert p.stages[0].uid is not None
-
-    for t in p.stages[0].tasks:
-        assert t.uid is not None
-
-
-# ------------------------------------------------------------------------------
-#
 def func_for_enqueue_test(p):
 
     while True:
@@ -124,7 +96,11 @@ def test_wfp_enqueue():
                       rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
 
-    wfp.initialize_workflow()
+    assert p.uid           is not None
+    assert p.stages[0].uid is not None
+
+    for t in p.stages[0].tasks:
+        assert t.uid is not None
 
     assert p.state           == states.INITIAL
     assert p.stages[0].state == states.INITIAL
@@ -183,8 +159,6 @@ def test_wfp_dequeue():
                       completed_queue=amgr._completed_queue,
                       rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
-
-    wfp.initialize_workflow()
 
     assert p.state           == states.INITIAL
     assert p.stages[0].state == states.INITIAL
@@ -306,8 +280,6 @@ def test_wfp_workflow_incomplete():
                       completed_queue=amgr._completed_queue,
                       rmq_conn_params=amgr._rmq_conn_params,
                       resubmit_failed=False)
-
-    wfp.initialize_workflow()
 
     for t in p.stages[0].tasks:
         t.state = states.COMPLETED

--- a/tests/test_integration/test_tproc_rp.py
+++ b/tests/test_integration/test_tproc_rp.py
@@ -249,8 +249,6 @@ def test_create_cud_from_task():
     s.tasks  = t1
     p.stages = s
 
-    p._assign_uid('test')
-
     cud = create_cud_from_task(t1, placeholders)
 
     assert cud.name == '%s,%s,%s,%s,%s,%s' % (t1.uid, t1.name,

--- a/tests/test_utils/test_prof_utils.py
+++ b/tests/test_utils/test_prof_utils.py
@@ -58,7 +58,6 @@ def test_write_session_description():
                             completed_queue=amgr._completed_queue,
                             resubmit_failed=amgr._resubmit_failed,
                             rmq_conn_params=amgr._rmq_conn_params)
-    amgr._wfp.initialize_workflow()
     amgr._workflow = amgr._wfp.workflow
 
     amgr._task_manager = TaskManager(sid=amgr._sid,
@@ -176,7 +175,6 @@ def test_write_workflows():
                                     resubmit_failed=amgr._resubmit_failed,
                                     rmq_conn_params=amgr._rmq_conn_params)
 
-        amgr._wfp.initialize_workflow()
         check = amgr.workflow
 
         # ----------------------------------------------------------------------
@@ -213,7 +211,6 @@ def test_write_workflows():
                                     completed_queue=amgr._completed_queue,
                                     resubmit_failed=amgr._resubmit_failed,
                                     rmq_conn_params=amgr._rmq_conn_params)
-        amgr._wfp.initialize_workflow()
         check = amgr.workflows
 
         data = write_workflows(amgr.workflows, 'test', fwrite=False)


### PR DESCRIPTION
This PR moves the UID creation for pipelines, tasks and stages into the respective constructors.  It also moves the assignment of `parent_stage` and `parent_pipeline` attributes into the `add_task` and `add_stage` methods which establishes that parental relationship.

This PR probably needs some thorough testing to ensure that no code depends on the late UID assignment.