### PR TITLE
update private attribute, _shared_data

### DIFF
--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -340,8 +340,11 @@ class AppManager(object):
                 raise ree.TypeError(expected_type=str,
                                     actual_type=type(value))
 
+        self._shared_data = data
+
         if self._rmgr:
             self._rmgr.shared_data = data
+
 
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
`shared_data` wasn't updated to the private attribute `_shared_data` of the class `AppManager`, although it is updated in the `_rmgr` if exists. This hotfix applies the change of the attribute in the class as well to address the issue from: https://github.com/radical-collaboration/hpc-workflows/issues/119