### PR TITLE
Doc string for a method

### DIFF
--- a/src/radical/entk/appman/wfprocessor.py
+++ b/src/radical/entk/appman/wfprocessor.py
@@ -374,7 +374,10 @@ class WFprocessor(object):
     # --------------------------------------------------------------------------
     #
     def _execute_post_exec(self, pipe, stage):
-
+        """
+        **Purpose**: This method executes the post_exec step of a stage for a
+        pipeline.
+        """
         try:
             self._logger.info('Executing post-exec for stage %s' % stage.uid)
             self._prof.prof('post_exec_start', uid=self._uid)


### PR DESCRIPTION
Closes #401.

I added a small doc string. After reading the method I found that it is self explanatory what is happening. So there is no need for something significant