### PR TITLE
Moving warning filter to the whole file.

### DIFF
--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -7,6 +7,9 @@ import radical.utils as ru
 from . import exceptions as ree
 from . import states     as res
 
+import warnings
+warnings.simplefilter(action="once", category=DeprecationWarning, lineno=707)
+warnings.simplefilter(action="once", category=DeprecationWarning, lineno=764)
 
 # ------------------------------------------------------------------------------
 #
@@ -701,10 +704,10 @@ class Task(object):
                              'cpu_process_type', 'cpu_thread_type'])
 
         if set(value.keys()).issubset(depr_expected_keys):
-            import warnings
-            warnings.simplefilter("once")
-            warnings.warn("CPU requirements keys are renamed using 'cpu_'" +
-                           "as a prefix for all keys.",DeprecationWarning)
+            warnings.warn("CPU requirements keys are renamed. Please use " +
+                          "cpu_processes for processes, cpu_process_type for " +
+                          "process_type, cpu_threads for threads_per_process " +
+                          "and cpu_thread_type for thread_type",DeprecationWarning)
 
             value['cpu_processes'] = value.pop('processes')
             value['cpu_process_type'] = value.pop('process_type')
@@ -758,10 +761,10 @@ class Task(object):
                              'gpu_process_type', 'gpu_thread_type'])
 
         if set(value.keys()).issubset(depr_expected_keys):
-            import warnings
-            warnings.simplefilter("once")
-            warnings.warn("GPU requirements keys are renamed using 'gpu_'" +
-                           "as a prefix for all keys.",DeprecationWarning)
+            warnings.warn("GPU requirements keys are renamed. Please use " +
+                          "gpu_processes for processes, gpu_process_type for " +
+                          "process_type, gpu_threads for threads_per_process " +
+                          "and gpu_thread_type for thread_type",DeprecationWarning)
 
             value['gpu_processes'] = value.pop('processes')
             value['gpu_process_type'] = value.pop('process_type')


### PR DESCRIPTION
I moved the warning filter to the whole file. It will make sure that the deprecation message will be printed once, regardless how many times a task is created. I am not sure how to create a test other than running something like:

```python
from radical.entk import Task
for _ in range(100):
    t = Task()
    t.cpu_reqs = {'processes': 16, 'process_type': 'MPI', 'threads_per_process': 1, 'thread_type': 'OpenMP'}
for _ in range(100):
    t = Task()
    t.gpu_reqs = {'processes': 16, 'process_type': 'MPI', 'threads_per_process': 1, 'thread_type': 'OpenMP'}
```

and observing the output.

This fixes #523.

