### PR TITLE
Added exception for any symbol apart from . in names

### DIFF
--- a/src/radical/entk/constants.py
+++ b/src/radical/entk/constants.py
@@ -1,0 +1,6 @@
+
+__copyright__ = 'Copyright 2014-2020, http://radical.rutgers.edu'
+__license__   = 'MIT'
+
+
+NAME_MESSAGE = "Valid object names can contain letters, numbers and '.'. Any other character is not allowed"

--- a/src/radical/entk/pipeline.py
+++ b/src/radical/entk/pipeline.py
@@ -6,9 +6,10 @@ import threading
 
 import radical.utils as ru
 
-from .exceptions import TypeError, ValueError, MissingError, EnTKError
-from .stage      import Stage
-from .           import states
+from string import punctuation
+from .      import exceptions as ree
+from .stage import Stage
+from .      import states
 
 
 class Pipeline(object):
@@ -156,20 +157,21 @@ class Pipeline(object):
 
     @name.setter
     def name(self, value):
-        if isinstance(value, str):
-            if ',' in value:
-                raise ValueError(obj=self._uid,
-                                attribute='name',
-                                actual_value=value,
-                                expected_value="Using ',' in an object's " +
-                                               "name will corrupt the " +
-                                               "profiling and internal " +
-                                               "mapping tables")
-            else:
-                self._name = value
 
-        else:
-            raise TypeError(expected_type=str, actual_type=type(value))
+        invalid_symbols = punctuation.replace('.','')
+        if not isinstance(value, str):
+            raise ree.TypeError(expected_type=str,
+                                actual_type=type(value))
+
+        if any(symbol in value for symbol in invalid_symbols):
+            raise ree.ValueError(obj=self._uid,
+                                 attribute='name',
+                                 actual_value=value,
+                                 expected_value="Valid object names can " +
+                                 "contains letters, numbers and '.'. Any "
+                                 "other character is not allowed")
+
+        self._name = value
 
     @stages.setter
     def stages(self, value):
@@ -190,12 +192,12 @@ class Pipeline(object):
                 if self._state != states.SUSPENDED:
                     self._state_history.append(value)
             else:
-                raise ValueError(obj=self._uid,
+                raise ree.ValueError(obj=self._uid,
                                  attribute='state',
                                  expected_value=list(states._pipeline_state_values.keys()),
                                  actual_value=value)
         else:
-            raise TypeError(expected_type=str, actual_type=type(value))
+            raise ree.TypeError(expected_type=str, actual_type=type(value))
 
 
     # --------------------------------------------------------------------------
@@ -254,6 +256,19 @@ class Pipeline(object):
 
         if 'name' in d:
             if d['name']:
+                invalid_symbols = punctuation.replace('.','')
+                if not isinstance(d['name'], str):
+                    raise ree.TypeError(expected_type=str,
+                                        actual_type=type(d['name']))
+
+                if any(symbol in d['name'] for symbol in invalid_symbols):
+                    raise ree.ValueError(obj=self._uid,
+                                        attribute='name',
+                                        actual_value=d['name'],
+                                        expected_value="Valid object names can " +
+                                        "contains letters, numbers and '.'. Any "
+                                        "other character is not allowed")
+
                 self._name = d['name']
 
         if 'state' in d:
@@ -261,12 +276,12 @@ class Pipeline(object):
                 if d['state'] in list(states._pipeline_state_values.keys()):
                     self._state = d['state']
                 else:
-                    raise ValueError(obj=self._uid,
+                    raise ree.ValueError(obj=self._uid,
                                      attribute='state',
                                      expected_value=list(states._pipeline_state_values.keys()),
                                      actual_value=d['state'])
             else:
-                raise TypeError(entity='state', expected_type=str,
+                raise ree.TypeError(entity='state', expected_type=str,
                                 actual_type=type(d['state']))
 
         else:
@@ -276,7 +291,7 @@ class Pipeline(object):
             if isinstance(d['state_history'], list):
                 self._state_history = d['state_history']
             else:
-                raise TypeError(entity='state_history', expected_type=list, actual_type=type(
+                raise ree.TypeError(entity='state_history', expected_type=list, actual_type=type(
                     d['state_history']))
 
         if 'completed' in d:
@@ -284,7 +299,7 @@ class Pipeline(object):
                 if d['completed']:
                     self._completed_flag.set()
             else:
-                raise TypeError(entity='completed', expected_type=bool,
+                raise ree.TypeError(entity='completed', expected_type=bool,
                                 actual_type=type(d['completed']))
 
     # --------------------------------------------------------------------------
@@ -300,7 +315,7 @@ class Pipeline(object):
          - The state of the pipeline will be set to `SUSPENDED`.
         '''
         if self._state == states.SUSPENDED:
-            raise EnTKError(
+            raise ree.EnTKError(
                 'suspend() called on Pipeline %s that is already suspended' % self._uid)
 
         self._state = states.SUSPENDED
@@ -319,7 +334,7 @@ class Pipeline(object):
            had before suspension.
         '''
         if self._state != states.SUSPENDED:
-            raise EnTKError('Cannot resume Pipeline %s: not suspended [%s] [%s]'
+            raise ree.EnTKError('Cannot resume Pipeline %s: not suspended [%s] [%s]'
                     % (self._uid, self._state, self._state_history))
 
         self._state = self._state_history[-2]
@@ -343,7 +358,7 @@ class Pipeline(object):
                 self._completed_flag.set()
 
         except Exception as ex:
-            raise EnTKError(msg=ex) from ex
+            raise ree.EnTKError(msg=ex) from ex
 
     def _decrement_stage(self):
         """
@@ -357,7 +372,7 @@ class Pipeline(object):
                 self._completed_flag = threading.Event()  # reset
 
         except Exception as ex:
-            raise EnTKError(msg=ex) from ex
+            raise ree.EnTKError(msg=ex) from ex
 
     @classmethod
     def _validate_entities(self, stages):
@@ -367,14 +382,14 @@ class Pipeline(object):
         :argument: list of Stage objects
         """
         if not stages:
-            raise TypeError(expected_type=Stage, actual_type=type(stages))
+            raise ree.TypeError(expected_type=Stage, actual_type=type(stages))
 
         if not isinstance(stages, list):
             stages = [stages]
 
         for value in stages:
             if not isinstance(value, Stage):
-                raise TypeError(expected_type=Stage, actual_type=type(value))
+                raise ree.TypeError(expected_type=Stage, actual_type=type(value))
 
         return stages
 
@@ -386,14 +401,14 @@ class Pipeline(object):
 
         if self._state is not states.INITIAL:
 
-            raise ValueError(obj=self._uid,
+            raise ree.ValueError(obj=self._uid,
                              attribute='state',
                              expected_value=states.INITIAL,
                              actual_value=self._state)
 
         if not self._stages:
 
-            raise MissingError(obj=self._uid,
+            raise ree.MissingError(obj=self._uid,
                                missing_attribute='stages')
 
         for stage in self._stages:

--- a/src/radical/entk/pipeline.py
+++ b/src/radical/entk/pipeline.py
@@ -6,10 +6,11 @@ import threading
 
 import radical.utils as ru
 
-from string import punctuation
-from .      import exceptions as ree
-from .stage import Stage
-from .      import states
+from string     import punctuation
+from .constants import NAME_MESSAGE
+from .          import exceptions as ree
+from .stage     import Stage
+from .          import states
 
 
 class Pipeline(object):
@@ -167,9 +168,7 @@ class Pipeline(object):
             raise ree.ValueError(obj=self._uid,
                                  attribute='name',
                                  actual_value=value,
-                                 expected_value="Valid object names can " +
-                                 "contains letters, numbers and '.'. Any "
-                                 "other character is not allowed")
+                                 expected_value=NAME_MESSAGE)
 
         self._name = value
 

--- a/src/radical/entk/stage.py
+++ b/src/radical/entk/stage.py
@@ -5,10 +5,11 @@ __license__   = 'MIT'
 
 import radical.utils as ru
 
-from string import punctuation
-from .      import exceptions as ree
-from .task  import Task
-from .      import states
+from string    import punctuation
+from .         import exceptions as ree
+from .constants import NAME_MESSAGE
+from .task     import Task
+from .         import states
 
 
 class Stage(object):
@@ -176,9 +177,7 @@ class Stage(object):
             raise ree.ValueError(obj=self._uid,
                                  attribute='name',
                                  actual_value=value,
-                                 expected_value="Valid object names can " +
-                                 "contains letters, numbers and '.'. Any "
-                                 "other character is not allowed")
+                                 expected_value=NAME_MESSAGE)
         self._name = value
 
     @tasks.setter

--- a/src/radical/entk/stage.py
+++ b/src/radical/entk/stage.py
@@ -5,9 +5,10 @@ __license__   = 'MIT'
 
 import radical.utils as ru
 
-from .exceptions import ValueError, TypeError, EnTKError, MissingError
-from .task       import Task
-from .           import states
+from string import punctuation
+from .      import exceptions as ree
+from .task  import Task
+from .      import states
 
 
 class Stage(object):
@@ -166,16 +167,19 @@ class Stage(object):
 
     @name.setter
     def name(self, value):
-        if isinstance(value, str):
-            if ',' in value:
-                raise ValueError(obj=self._uid,
-                                attribute='name',
-                                actual_value=value,
-                                expected_value="Using ',' in an object's name will corrupt the profiling and internal mapping tables")
-            else:
-                self._name = value
-        else:
-            raise TypeError(expected_type=str, actual_type=type(value))
+        invalid_symbols = punctuation.replace('.','')
+        if not isinstance(value, str):
+            raise ree.TypeError(expected_type=str,
+                                actual_type=type(value))
+
+        if any(symbol in value for symbol in invalid_symbols):
+            raise ree.ValueError(obj=self._uid,
+                                 attribute='name',
+                                 actual_value=value,
+                                 expected_value="Valid object names can " +
+                                 "contains letters, numbers and '.'. Any "
+                                 "other character is not allowed")
+        self._name = value
 
     @tasks.setter
     def tasks(self, value):
@@ -187,7 +191,7 @@ class Stage(object):
         if isinstance(value, dict):
             self._p_pipeline = value
         else:
-            raise TypeError(expected_type=dict, actual_type=type(value))
+            raise ree.TypeError(expected_type=dict, actual_type=type(value))
 
     @state.setter
     def state(self, value):
@@ -196,19 +200,19 @@ class Stage(object):
                 self._state = value
                 self._state_history.append(value)
             else:
-                raise ValueError(obj=self._uid,
+                raise ree.ValueError(obj=self._uid,
                                  attribute='state',
                                  expected_value=list(states._stage_state_values.keys()),
                                  actual_value=value)
         else:
-            raise TypeError(expected_type=str, actual_type=type(value))
+            raise ree.TypeError(expected_type=str, actual_type=type(value))
 
     @post_exec.setter
     def post_exec(self, value):
 
         if not callable(value):
 
-            raise TypeError(entity='stage %s branch' % self._uid,
+            raise ree.TypeError(entity='stage %s branch' % self._uid,
                             expected_type='callable',
                             actual_type=type(value)
                             )
@@ -271,6 +275,18 @@ class Stage(object):
 
         if 'name' in d:
             if d['name']:
+                invalid_symbols = punctuation.replace('.','')
+                if not isinstance(d['name'], str):
+                    raise ree.TypeError(expected_type=str,
+                                        actual_type=type(d['name']))
+
+                if any(symbol in d['name'] for symbol in invalid_symbols):
+                    raise ree.ValueError(obj=self._uid,
+                                        attribute='name',
+                                        actual_value=d['name'],
+                                        expected_value="Valid object names can " +
+                                        "contains letters, numbers and '.'. Any "
+                                        "other character is not allowed")
                 self._name = d['name']
 
         if 'state' in d:
@@ -279,12 +295,12 @@ class Stage(object):
                     self._state = d['state']
                 else:
                     value = d['state']
-                    raise ValueError(obj=self._uid,
+                    raise ree.ValueError(obj=self._uid,
                                      attribute='state',
                                      expected_value=list(states._stage_state_values.keys()),
                                      actual_value=value)
             else:
-                raise TypeError(entity='state', expected_type=str, actual_type=type(d['state']))
+                raise ree.TypeError(entity='state', expected_type=str, actual_type=type(d['state']))
 
         else:
             self._state = states.INITIAL
@@ -293,13 +309,13 @@ class Stage(object):
             if isinstance(d['state_history'], list):
                 self._state_history = d['state_history']
             else:
-                raise TypeError(entity='state_history', expected_type=list, actual_type=type(d['state_history']))
+                raise ree.TypeError(entity='state_history', expected_type=list, actual_type=type(d['state_history']))
 
         if 'parent_pipeline' in d:
             if isinstance(d['parent_pipeline'], dict):
                 self._p_pipeline = d['parent_pipeline']
             else:
-                raise TypeError(entity='parent_pipeline', expected_type=dict, actual_type=type(d['parent_pipeline']))
+                raise ree.TypeError(entity='parent_pipeline', expected_type=dict, actual_type=type(d['parent_pipeline']))
 
     # ------------------------------------------------------------------------------------------------------------------
     # Private methods
@@ -312,7 +328,7 @@ class Stage(object):
         :arguments: String
         """
         if value not in list(states.state_numbers.keys()):
-            raise ValueError(obj=self._uid,
+            raise ree.ValueError(obj=self._uid,
                              attribute='set_tasks_state',
                              expected_value=list(states.state_numbers.keys()),
                              actual_value=value)
@@ -334,7 +350,7 @@ class Stage(object):
             return True
 
         except Exception as ex:
-            raise EnTKError(msg=ex) from ex
+            raise ree.EnTKError(msg=ex) from ex
 
     @classmethod
     def _validate_entities(self, tasks):
@@ -343,7 +359,7 @@ class Stage(object):
         """
 
         if not tasks:
-            raise TypeError(expected_type=Task, actual_type=type(tasks))
+            raise ree.TypeError(expected_type=Task, actual_type=type(tasks))
 
         if not isinstance(tasks, set):
 
@@ -355,7 +371,7 @@ class Stage(object):
         for t in tasks:
 
             if not isinstance(t, Task):
-                raise TypeError(expected_type=Task, actual_type=type(t))
+                raise ree.TypeError(expected_type=Task, actual_type=type(t))
 
         return tasks
 
@@ -367,14 +383,14 @@ class Stage(object):
 
         if self._state is not states.INITIAL:
 
-            raise ValueError(obj=self._uid,
+            raise ree.ValueError(obj=self._uid,
                              attribute='state',
                              expected_value=states.INITIAL,
                              actual_value=self._state)
 
         if not self._tasks:
 
-            raise MissingError(obj=self._uid,
+            raise ree.MissingError(obj=self._uid,
                                missing_attribute='tasks')
 
         for task in self._tasks:

--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -4,6 +4,7 @@ __license__   = 'MIT'
 
 import radical.utils as ru
 
+from string import punctuation
 from . import exceptions as ree
 from . import states     as res
 
@@ -84,7 +85,7 @@ class Task(object):
 
         # populate task attributes if so requesteed
         if from_dict:
-
+            
             if not isinstance(from_dict, dict):
                 raise ree.TypeError(expected_type=dict,
                                     actual_type=type(from_dict))
@@ -593,17 +594,18 @@ class Task(object):
 
     @name.setter
     def name(self, value):
-
+        invalid_symbols = punctuation.replace('.','')
         if not isinstance(value, str):
             raise ree.TypeError(expected_type=str,
                                 actual_type=type(value))
 
-        if ',' in value:
+        if any(symbol in value for symbol in invalid_symbols):
             raise ree.ValueError(obj=self._uid,
                                  attribute='name',
                                  actual_value=value,
-                                 expected_value="Using ',' in an object's name"
-                                 "will corrupt internal mapping tables")
+                                 expected_value="Valid object names can " +
+                                 "contains letters, numbers and '.'. Any "
+                                 "other character is not allowed")
 
         self._name = value
 

--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -4,7 +4,9 @@ __license__   = 'MIT'
 
 import radical.utils as ru
 
-from string import punctuation
+from string     import punctuation
+from .constants import NAME_MESSAGE
+
 from . import exceptions as ree
 from . import states     as res
 
@@ -604,9 +606,7 @@ class Task(object):
             raise ree.ValueError(obj=self._uid,
                                  attribute='name',
                                  actual_value=value,
-                                 expected_value="Valid object names can " +
-                                 "contains letters, numbers and '.'. Any "
-                                 "other character is not allowed")
+                                 expected_value=NAME_MESSAGE)
 
         self._name = value
 

--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -12,6 +12,7 @@ import warnings
 warnings.simplefilter(action="once", category=DeprecationWarning, lineno=707)
 warnings.simplefilter(action="once", category=DeprecationWarning, lineno=764)
 
+
 # ------------------------------------------------------------------------------
 #
 class Task(object):
@@ -85,7 +86,7 @@ class Task(object):
 
         # populate task attributes if so requesteed
         if from_dict:
-            
+
             if not isinstance(from_dict, dict):
                 raise ree.TypeError(expected_type=dict,
                                     actual_type=type(from_dict))

--- a/tests/test_component/test_pipeline.py
+++ b/tests/test_component/test_pipeline.py
@@ -56,7 +56,9 @@ class TestBase(TestCase):
     @mock.patch('radical.utils.generate_id', return_value='pipeline.0000')
     @mock.patch('threading.Lock', return_value='test_lock')
     @mock.patch('threading.Event', return_value='test_event')
-    @given(t=st.text(alphabet=string.ascii_letters + ',', min_size=10).filter(lambda x: ',' in x),
+    @given(t=st.text(alphabet=string.ascii_letters +
+                              string.punctuation.replace('.',''),
+                              min_size=10).filter(lambda x: any(symbol in x for symbol in string.punctuation)),
         l=st.lists(st.text()),
         i=st.integers().filter(lambda x: type(x) == int),
         b=st.booleans(),

--- a/tests/test_component/test_stage.py
+++ b/tests/test_component/test_stage.py
@@ -5,6 +5,7 @@ from random import shuffle
 
 from   hypothesis import given, settings
 import hypothesis.strategies as st
+import string
 
 from radical.entk import Stage, Task
 from radical.entk import states
@@ -47,7 +48,9 @@ class TestBase(TestCase):
     # ------------------------------------------------------------------------------
     #
     @mock.patch('radical.utils.generate_id', return_value='stage.0000')
-    @given(t=st.text(),
+    @given(t=st.text(alphabet=string.ascii_letters +
+                              string.punctuation.replace('.',''),
+                              min_size=10).filter(lambda x: any(symbol in x for symbol in string.punctuation)),
            l=st.lists(st.text()),
            i=st.integers().filter(lambda x: type(x) == int),
            b=st.booleans(),
@@ -64,10 +67,12 @@ class TestBase(TestCase):
 
         for data in data_type:
 
-            print('Using: %s, %s' % (data, type(data)))
-
             if not isinstance(data, str):
                 with self.assertRaises(TypeError):
+                    s.name = data
+
+            if isinstance(data,str):
+                with self.assertRaises(ValueError):
                     s.name = data
 
             with self.assertRaises(TypeError):

--- a/tests/test_component/test_tmgr_base.py
+++ b/tests/test_component/test_tmgr_base.py
@@ -175,9 +175,6 @@ class TestBase(TestCase):
         tmgr = Tmgr('test_tmgr', ['pending_queues'], ['completed_queues'], 
                      rmgr, rmq_params, 'test_rts')
 
-        def _tmgr_side_effect(amount):
-            time.sleep(amount)
-
         tmgr._tmgr_process = mt.Thread(target=_tmgr_side_effect,
                                        name='test_tmgr', args=(1))
         tmgr._tmgr_process.start()

--- a/tests/test_component/test_tmgr_base.py
+++ b/tests/test_component/test_tmgr_base.py
@@ -175,8 +175,11 @@ class TestBase(TestCase):
         tmgr = Tmgr('test_tmgr', ['pending_queues'], ['completed_queues'], 
                      rmgr, rmq_params, 'test_rts')
 
+        def _tmgr_side_effect(amount):
+            time.sleep(amount)
+
         tmgr._tmgr_process = mt.Thread(target=_tmgr_side_effect,
-                                       name='test_tmgr', args=(1))
+                                       name='test_tmgr', args=(1,))
         tmgr._tmgr_process.start()
 
         self.assertTrue(tmgr.check_manager())


### PR DESCRIPTION
This PR fixes #392.

It raises an exception if any symbol other than '.' is used in the name of a task, stage, or pipeline.