### PR TITLE
pypi version check

### DIFF
--- a/src/radical/entk/__init__.py
+++ b/src/radical/entk/__init__.py
@@ -11,14 +11,26 @@ from .appman.appmanager import AppManager
 
 # ------------------------------------------------------------------------------
 #
-import os            as _os
-import radical.utils as _ru
+import warnings
+import os                           as _os
+import radical.utils                as _ru
+import requests                     as req
+from packaging.version import parse as parse_version
+
+def custom_formatwarning(msg, *args, **kwargs):
+    # ignore everything except the message
+    return str(msg) + '\n'
+
+warnings.formatwarning = custom_formatwarning
 
 version_short, version_detail, version_base, version_branch, \
         sdist_name, sdist_path = _ru.get_version(_os.path.dirname(__file__))
 
 version = version_short
 
-
+r = req.get("https://pypi.org/pypi/radical.entk/json")
+versions = r.json()["releases"].keys()
+last_version = list(versions)[-1]
+if parse_version(version) < parse_version(last_version):
+    warnings.warn("WARNING: You are using radical.entk version %s, however version %s is available." % (version, last_version), UserWarning)
 # ------------------------------------------------------------------------------
-


### PR DESCRIPTION
This PR checks the version of the installed EnTK and the latest version on pypi and produces a warning message if the pypi version is more recent:

```
WARNING: You are using radical.entk version 1.5.9, however version 1.5.10 is available.
```

It will make sense two releases from now.

Fixes #476