### PR TITLE
Examples sync to devel

### DIFF
--- a/examples/misc/async_repex.py
+++ b/examples/misc/async_repex.py
@@ -195,7 +195,7 @@ class Replica(re.Pipeline):
         self._ex_list   = None  # list of replicas used in exchange step
 
         re.Pipeline.__init__(self)
-        self.name = 'p_%s' % self.rid
+        self.name = 'p.%s' % self.rid
         self._log = ru.Logger('radical.repex.rep')
 
         # add an initial md stage
@@ -224,7 +224,7 @@ class Replica(re.Pipeline):
         self._log.debug('=== %s add md', self.rid)
 
         task = re.Task()
-        task.name        = 'mdtsk-%s-%s' % (self.rid, self.cycle)
+        task.name        = 'mdtsk.%s.%s' % (self.rid, self.cycle)
         task.executable  = 'sleep'
         task.arguments   = [str(random.randint(0, 20)/10.0)]
 

--- a/examples/misc/async_repex.py
+++ b/examples/misc/async_repex.py
@@ -10,6 +10,7 @@ import radical.utils as ru
 
 t_0 = time.time()
 
+
 # ------------------------------------------------------------------------------
 #
 class ReplicaExchange(re.AppManager):
@@ -226,7 +227,7 @@ class Replica(re.Pipeline):
         task = re.Task()
         task.name        = 'mdtsk.%s.%s' % (self.rid, self.cycle)
         task.executable  = 'sleep'
-        task.arguments   = [str(random.randint(0, 20)/10.0)]
+        task.arguments   = [str(random.randint(0, 20) / 10.0)]
 
         stage = re.Stage()
         stage.add_tasks(task)

--- a/examples/simple/poe.py
+++ b/examples/simple/poe.py
@@ -95,16 +95,10 @@ if __name__ == '__main__':
     # resource, walltime, and cpus
     # resource is 'local.localhost' to execute locally
     res_dict = {
-
-    #    'resource': 'ncsa.bw_aprun',
-    #    'walltime': 10,
-    #    'cpus': 32,
-    #'project': 'bamm',
-    #'queue': 'high'
-	'resource': 'local.localhost',
-	'walltime': 10,
-	'cpus':2
-    }
+                'resource': 'local.localhost',
+                'walltime': 10,
+                'cpus':2
+                }
 
     # Assign resource request description to the Application Manager
     appman.resource_desc = res_dict

--- a/examples/simple/poe.py
+++ b/examples/simple/poe.py
@@ -5,7 +5,7 @@ import os
 
 # ------------------------------------------------------------------------------
 # Set default verbosity
-if os.environ.get('RADICAL_ENTK_VERBOSE') == None:
+if os.environ.get('RADICAL_ENTK_VERBOSE') is None:
     os.environ['RADICAL_ENTK_REPORT'] = 'True'
 
 
@@ -86,6 +86,7 @@ def generate_pipeline():
 
     return p
 
+
 if __name__ == '__main__':
 
     # Create Application Manager
@@ -98,7 +99,7 @@ if __name__ == '__main__':
                 'resource': 'local.localhost',
                 'walltime': 10,
                 'cpus':2
-                }
+                 }
 
     # Assign resource request description to the Application Manager
     appman.resource_desc = res_dict

--- a/examples/user_guide/add_data.py
+++ b/examples/user_guide/add_data.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
 
     # Create another Stage object
     s2 = Stage()
-    s2.name = 'Stage 2'
+    s2.name = 'Stage.2'
 
     # Create a Task object
     t2 = Task()

--- a/examples/user_guide/add_pipelines.py
+++ b/examples/user_guide/add_pipelines.py
@@ -31,13 +31,13 @@ def generate_pipeline(name, stages):
 
         # Create a Stage object
         s = Stage()
-        s.name = 'Stage %s' % s_cnt
+        s.name = 'Stage.%s' % s_cnt
 
         for t_cnt in range(5):
 
             # Create a Task object
             t = Task()
-            t.name = 'my-task'        # Assign a name to the task (optional)
+            t.name = 'my.task'        # Assign a name to the task (optional)
             t.executable = '/bin/echo'   # Assign executable to the task
             # Assign arguments for the task executable
             t.arguments = ['I am task %s in %s in %s' % (t_cnt, s_cnt, name)]

--- a/examples/user_guide/add_stages.py
+++ b/examples/user_guide/add_stages.py
@@ -26,13 +26,13 @@ if __name__ == '__main__':
 
     # Create a Stage object
     s1 = Stage()
-    s1.name = 'Stage 1'
+    s1.name = 'Stage.1'
 
     for cnt in range(10):
 
         # Create a Task object
         t = Task()
-        t.name = 'my-task'        # Assign a name to the task (optional)
+        t.name = 'my.task'        # Assign a name to the task (optional)
         t.executable = '/bin/echo'   # Assign executable to the task
         t.arguments = ['I am task %s in %s' % (cnt, s1.name)]  # Assign arguments for the task executable
 
@@ -45,13 +45,13 @@ if __name__ == '__main__':
 
     # Create another Stage object
     s2 = Stage()
-    s2.name = 'Stage 2'
+    s2.name = 'Stage.2'
 
     for cnt in range(5):
 
         # Create a Task object
         t = Task()
-        t.name = 'my-task'        # Assign a name to the task (optional, do not use ',' or '_')
+        t.name = 'my.task'        # Assign a name to the task (optional, do not use ',' or '_')
         t.executable = '/bin/echo'   # Assign executable to the task
         t.arguments = ['I am task %s in %s' % (cnt, s2.name)]  # Assign arguments for the task executable
 

--- a/examples/user_guide/add_tasks.py
+++ b/examples/user_guide/add_tasks.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
         # Create a Task object
         t = Task()
-        t.name = 'my-task'        # Assign a name to the task (optional, do not use ',' or '_')
+        t.name = 'my.task'        # Assign a name to the task (optional, do not use ',' or '_')
         t.executable = '/bin/echo'   # Assign executable to the task
         t.arguments = ['I am task %s' % cnt]  # Assign arguments for the task executable
 

--- a/examples/user_guide/get_started.py
+++ b/examples/user_guide/get_started.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 
     # Create a Task object
     t = Task()
-    t.name = 'my-first-task'        # Assign a name to the task (optional, do not use ',' or '_')
+    t.name = 'my.first.task'        # Assign a name to the task (optional, do not use ',' or '_')
     t.executable = '/bin/echo'   # Assign executable to the task
     t.arguments = ['Hello World']  # Assign arguments for the task executable
 

--- a/src/radical/entk/constants.py
+++ b/src/radical/entk/constants.py
@@ -3,4 +3,4 @@ __copyright__ = 'Copyright 2014-2020, http://radical.rutgers.edu'
 __license__   = 'MIT'
 
 
-NAME_MESSAGE = "Valid object names can contain letters, numbers and '.'. Any other character will not be allowed in version 1.5.10"
+NAME_MESSAGE = "Valid object names can contain letters, numbers and '.'. Any other character will not be allowed in versions >= 1.5.10"

--- a/src/radical/entk/constants.py
+++ b/src/radical/entk/constants.py
@@ -3,4 +3,4 @@ __copyright__ = 'Copyright 2014-2020, http://radical.rutgers.edu'
 __license__   = 'MIT'
 
 
-NAME_MESSAGE = "Valid object names can contain letters, numbers and '.'. Any other character is not allowed"
+NAME_MESSAGE = "Valid object names can contain letters, numbers and '.'. Any other character will not be allowed in version 1.5.10"

--- a/src/radical/entk/pipeline.py
+++ b/src/radical/entk/pipeline.py
@@ -3,6 +3,7 @@ __copyright__ = 'Copyright 2014-2020, http://radical.rutgers.edu'
 __license__   = 'MIT'
 
 import threading
+import warnings
 
 import radical.utils as ru
 
@@ -165,10 +166,11 @@ class Pipeline(object):
                                 actual_type=type(value))
 
         if any(symbol in value for symbol in invalid_symbols):
-            raise ree.ValueError(obj=self._uid,
-                                 attribute='name',
-                                 actual_value=value,
-                                 expected_value=NAME_MESSAGE)
+            warnings.warn(NAME_MESSAGE, DeprecationWarning)
+            # raise ree.ValueError(obj=self._uid,
+            #                      attribute='name',
+            #                      actual_value=value,
+            #                      expected_value=NAME_MESSAGE)
 
         self._name = value
 

--- a/src/radical/entk/stage.py
+++ b/src/radical/entk/stage.py
@@ -4,6 +4,7 @@ __license__   = 'MIT'
 
 
 import radical.utils as ru
+import warnings
 
 from string    import punctuation
 from .         import exceptions as ree
@@ -174,10 +175,11 @@ class Stage(object):
                                 actual_type=type(value))
 
         if any(symbol in value for symbol in invalid_symbols):
-            raise ree.ValueError(obj=self._uid,
-                                 attribute='name',
-                                 actual_value=value,
-                                 expected_value=NAME_MESSAGE)
+            warnings.warn(NAME_MESSAGE, DeprecationWarning)
+            # raise ree.ValueError(obj=self._uid,
+            #                      attribute='name',
+            #                      actual_value=value,
+            #                      expected_value=NAME_MESSAGE)
         self._name = value
 
     @tasks.setter

--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -11,8 +11,8 @@ from . import exceptions as ree
 from . import states     as res
 
 import warnings
-warnings.simplefilter(action="once", stacklevel=2, category=DeprecationWarning, lineno=707)
-warnings.simplefilter(action="once", stacklevel=2, category=DeprecationWarning, lineno=764)
+warnings.simplefilter(action="once", category=DeprecationWarning, lineno=707)
+warnings.simplefilter(action="once", category=DeprecationWarning, lineno=764)
 
 
 # ------------------------------------------------------------------------------
@@ -603,7 +603,7 @@ class Task(object):
                                 actual_type=type(value))
 
         if any(symbol in value for symbol in invalid_symbols):
-            warnings.warn(NAME_MESSAGE, DeprecationWarning)
+            warnings.warn(NAME_MESSAGE, DeprecationWarning, stacklevel=2)
             # raise ree.ValueError(obj=self._uid,
             #                      attribute='name',
             #                      actual_value=value,
@@ -711,7 +711,8 @@ class Task(object):
             warnings.warn("CPU requirements keys are renamed. Please use " +
                           "cpu_processes for processes, cpu_process_type for " +
                           "process_type, cpu_threads for threads_per_process " +
-                          "and cpu_thread_type for thread_type",DeprecationWarning)
+                          "and cpu_thread_type for thread_type",
+                          DeprecationWarning, stacklevel=2)
 
             value['cpu_processes'] = value.pop('processes')
             value['cpu_process_type'] = value.pop('process_type')
@@ -768,7 +769,8 @@ class Task(object):
             warnings.warn("GPU requirements keys are renamed. Please use " +
                           "gpu_processes for processes, gpu_process_type for " +
                           "process_type, gpu_threads for threads_per_process " +
-                          "and gpu_thread_type for thread_type",DeprecationWarning)
+                          "and gpu_thread_type for thread_type",
+                          DeprecationWarning, stacklevel=2)
 
             value['gpu_processes'] = value.pop('processes')
             value['gpu_process_type'] = value.pop('process_type')

--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -11,8 +11,8 @@ from . import exceptions as ree
 from . import states     as res
 
 import warnings
-warnings.simplefilter(action="once", category=DeprecationWarning, lineno=707)
-warnings.simplefilter(action="once", category=DeprecationWarning, lineno=764)
+warnings.simplefilter(action="once", stacklevel=2, category=DeprecationWarning, lineno=707)
+warnings.simplefilter(action="once", stacklevel=2, category=DeprecationWarning, lineno=764)
 
 
 # ------------------------------------------------------------------------------
@@ -603,10 +603,11 @@ class Task(object):
                                 actual_type=type(value))
 
         if any(symbol in value for symbol in invalid_symbols):
-            raise ree.ValueError(obj=self._uid,
-                                 attribute='name',
-                                 actual_value=value,
-                                 expected_value=NAME_MESSAGE)
+            warnings.warn(NAME_MESSAGE, DeprecationWarning)
+            # raise ree.ValueError(obj=self._uid,
+            #                      attribute='name',
+            #                      actual_value=value,
+            #                      expected_value=NAME_MESSAGE)
 
         self._name = value
 

--- a/tests/test_component/test_pipeline.py
+++ b/tests/test_component/test_pipeline.py
@@ -3,7 +3,7 @@
 
 from unittest import TestCase
 from random import shuffle
-import string
+# import string
 
 from   hypothesis import given, settings
 import hypothesis.strategies as st

--- a/tests/test_component/test_pipeline.py
+++ b/tests/test_component/test_pipeline.py
@@ -53,23 +53,24 @@ class TestBase(TestCase):
 
     # --------------------------------------------------------------------------
     #
+    # @given(t=st.text(alphabet=string.ascii_letters +
+    #                           string.punctuation.replace('.', ''),
+    #                  min_size=10).filter(
+    #     lambda x: any(symbol in x for symbol in string.punctuation)),
     @mock.patch('radical.utils.generate_id', return_value='pipeline.0000')
     @mock.patch('threading.Lock', return_value='test_lock')
     @mock.patch('threading.Event', return_value='test_event')
-    @given(t=st.text(alphabet=string.ascii_letters +
-                              string.punctuation.replace('.',''),
-                              min_size=10).filter(lambda x: any(symbol in x for symbol in string.punctuation)),
-        l=st.lists(st.text()),
+    @given(l=st.lists(st.text()),
         i=st.integers().filter(lambda x: type(x) == int),
         b=st.booleans(),
         se=st.sets(st.text()))
     def test_pipeline_assignment_exceptions(self, mocked_generate_id,
-                                            mocked_Lock, mocked_Event, t, l, i,
+                                            mocked_Lock, mocked_Event, l, i,
                                             b, se):
 
         p = Pipeline()
 
-        data_type = [t, l, i, b, se]
+        data_type = [l, i, b, se]
         print(data_type)
 
         for data in data_type:

--- a/tests/test_component/test_stage.py
+++ b/tests/test_component/test_stage.py
@@ -47,15 +47,16 @@ class TestBase(TestCase):
 
     # ------------------------------------------------------------------------------
     #
+    # @given(t=st.text(alphabet=string.ascii_letters +
+    #                           string.punctuation.replace('.', ''),
+    #                  min_size=10).filter(
+    #     lambda x: any(symbol in x for symbol in string.punctuation)),
     @mock.patch('radical.utils.generate_id', return_value='stage.0000')
-    @given(t=st.text(alphabet=string.ascii_letters +
-                              string.punctuation.replace('.',''),
-                              min_size=10).filter(lambda x: any(symbol in x for symbol in string.punctuation)),
-           l=st.lists(st.text()),
+    @given(l=st.lists(st.text()),
            i=st.integers().filter(lambda x: type(x) == int),
            b=st.booleans(),
            se=st.sets(st.text()))
-    def test_stage_exceptions(self, mocked_generate_id, t, l, i, b, se):
+    def test_stage_exceptions(self, mocked_generate_id, l, i, b, se):
         """
         ***Purpose***: Test if correct exceptions are raised when attributes are
         assigned unacceptable values.
@@ -63,7 +64,7 @@ class TestBase(TestCase):
 
         s = Stage()
 
-        data_type = [t, l, i, b, se]
+        data_type = [l, i, b, se]
 
         for data in data_type:
 
@@ -71,9 +72,9 @@ class TestBase(TestCase):
                 with self.assertRaises(TypeError):
                     s.name = data
 
-            if isinstance(data,str):
-                with self.assertRaises(ValueError):
-                    s.name = data
+            # if isinstance(data,str):
+            #     with self.assertRaises(ValueError):
+            #         s.name = data
 
             with self.assertRaises(TypeError):
                 s.tasks = data

--- a/tests/test_component/test_stage.py
+++ b/tests/test_component/test_stage.py
@@ -5,7 +5,7 @@ from random import shuffle
 
 from   hypothesis import given, settings
 import hypothesis.strategies as st
-import string
+# import string
 
 from radical.entk import Stage, Task
 from radical.entk import states


### PR DESCRIPTION
This PR fixes the examples to use the new naming convention and demotes the exception to a warning. The warning will appear for all names always.

It will probably annoy our users, but I hope they do the change instead of asking us to silence it. 