### PR TITLE
Fix/issue 509

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,4 @@ coverage:
         threshold: 1%
         paths: 
           - "src"
+    patch: off

--- a/src/radical/entk/execman/base/task_manager.py
+++ b/src/radical/entk/execman/base/task_manager.py
@@ -151,7 +151,8 @@ class Base_TaskManager(object):
         try:
             channel.basic_publish(exchange='', routing_key=queue, body=body,
                         properties=pika.BasicProperties(correlation_id=corr_id))
-        except pika.exceptions.ConnectionClosed:
+        except (pika.exceptions.ConnectionClosed,
+                pika.exceptions.ChannelClosed):
             connection = pika.BlockingConnection(conn_params)
             channel = connection.channel()
             channel.basic_publish(exchange='', routing_key=queue, body=body,
@@ -254,7 +255,8 @@ class Base_TaskManager(object):
                                              routing_key=self._hb_request_q,
                                              properties=props,
                                              body='request')
-                except pika.exceptions.ConnectionClosed:
+                except (pika.exceptions.ConnectionClosed,
+                        pika.exceptions.ChannelClosed):
                     mq_connection = pika.BlockingConnection(self._rmq_conn_params)
                     mq_channel = mq_connection.channel()
                     props = pika.BasicProperties(reply_to=self._hb_response_q,

--- a/src/radical/entk/execman/base/task_manager.py
+++ b/src/radical/entk/execman/base/task_manager.py
@@ -275,11 +275,13 @@ class Base_TaskManager(object):
                                                       queue=self._hb_response_q)
                 if not body:
                     # no usable response
+                    self._log.error('Heartbeat response no body')
                     return
                     # raise EnTKError('heartbeat timeout')
 
                 if corr_id != props.correlation_id:
                     # incorrect response
+                    self._log.error('Heartbeat response wrong correlation')
                     return
                     # raise EnTKError('heartbeat timeout')
 

--- a/src/radical/entk/execman/rp/task_manager.py
+++ b/src/radical/entk/execman/rp/task_manager.py
@@ -245,10 +245,11 @@ class TaskManager(Base_TaskManager):
                                                            'rts_uid': rts_uid}
 
         # ----------------------------------------------------------------------
-        def unit_state_cb(unit, state, mq_channel, conn_params):
+        def unit_state_cb(unit, state, cb_data):
 
             try:
-                channel = mq_channel
+                channel = cb_data['channel']
+                conn_params = cb_data['params']
                 self._log.debug('Unit %s in state %s' % (unit.uid, unit.state))
 
                 if unit.state in rp.FINAL:
@@ -295,7 +296,8 @@ class TaskManager(Base_TaskManager):
 
         umgr = rp.UnitManager(session=rmgr._session)
         umgr.add_pilots(rmgr.pilot)
-        umgr.register_callback(unit_state_cb)
+        umgr.register_callback(unit_state_cb, cb_data={'channel': mq_channel,
+                                                       'params': rmq_conn_params})
 
         try:
 

--- a/src/radical/entk/execman/rp/task_manager.py
+++ b/src/radical/entk/execman/rp/task_manager.py
@@ -104,30 +104,39 @@ class TaskManager(Base_TaskManager):
         try:
 
             # ------------------------------------------------------------------
-            def heartbeat_response(mq_channel):
+            def heartbeat_response(mq_channel, conn_params):
 
+                channel = mq_channel
                 try:
 
                     # Get request from heartbeat-req for heartbeat response
                     method_frame, props, body = \
-                                  mq_channel.basic_get(queue=self._hb_request_q)
+                                  channel.basic_get(queue=self._hb_request_q)
 
                     if not body:
                         return
 
                     self._log.info('Received heartbeat request')
-
-                    nprops = pika.BasicProperties(
+                    try:
+                        nprops = pika.BasicProperties(
                                             correlation_id=props.correlation_id)
-                    mq_channel.basic_publish(
-                                exchange='',
-                                routing_key=self._hb_response_q,
-                                properties=nprops,
-                                body='response')
+                        channel.basic_publish(exchange='',
+                                                 routing_key=self._hb_response_q,
+                                                 properties=nprops,
+                                                 body='response')
+                    except pika.exceptions.ConnectionClosed:
+                        connection = pika.BlockingConnection(conn_params)
+                        channel = connection.channel()
+                        nprops = pika.BasicProperties(
+                                            correlation_id=props.correlation_id)
+                        channel.basic_publish(exchange='',
+                                                 routing_key=self._hb_response_q,
+                                                 properties=nprops,
+                                                 body='response')
 
                     self._log.info('Sent heartbeat response')
 
-                    mq_channel.basic_ack(delivery_tag=method_frame.delivery_tag)
+                    channel.basic_ack(delivery_tag=method_frame.delivery_tag)
 
                 except Exception as ex:
                     self._log.exception('Failed to respond to heartbeat, ' +
@@ -173,7 +182,7 @@ class TaskManager(Base_TaskManager):
                         mq_channel.basic_ack(
                                 delivery_tag=method_frame.delivery_tag)
 
-                    heartbeat_response(mq_channel)
+                    heartbeat_response(mq_channel, rmq_conn_params)
 
                 except Exception as ex:
                     self._log.exception('Error in task execution: %s', ex)
@@ -248,16 +257,23 @@ class TaskManager(Base_TaskManager):
                     task = create_task_from_cu(unit, self._prof)
 
                     self._advance(task, 'Task', states.COMPLETED,
-                                  mq_channel, '%s-cb-to-sync' % self._sid)
+                                  mq_channel, rmq_conn_params,
+                                  '%s-cb-to-sync' % self._sid)
 
                     load_placeholder(task, unit.uid)
 
                     task_as_dict = json.dumps(task.to_dict())
+                    try:
+                        mq_channel.basic_publish(exchange='',
+                                                 routing_key='%s-completedq-1' % self._sid,
+                                                 body=task_as_dict)
+                    except pika.exceptions.ConnectionClosed:
+                        connection = pika.BlockingConnection(rmq_conn_params)
+                        mq_channel = connection.channel()
+                        mq_channel.basic_publish(exchange='',
+                                                 routing_key='%s-completedq-1' % self._sid,
+                                                 body=task_as_dict)
 
-                    mq_channel.basic_publish(
-                            exchange='',
-                            routing_key='%s-completedq-1' % self._sid,
-                            body=task_as_dict)
 
                     self._log.info('Pushed task %s with state %s to completed '
                                    'queue %s-completedq-1',
@@ -311,7 +327,8 @@ class TaskManager(Base_TaskManager):
                                             task, placeholders, self._prof))
 
                     self._advance(task, 'Task', states.SUBMITTING,
-                                  mq_channel, '%s-tmgr-to-sync' % self._sid)
+                                  mq_channel, rmq_conn_params,
+                                  '%s-tmgr-to-sync' % self._sid)
 
                 umgr.submit_units(bulk_cuds)
             mq_connection.close()

--- a/src/radical/entk/execman/rp/task_manager.py
+++ b/src/radical/entk/execman/rp/task_manager.py
@@ -124,7 +124,8 @@ class TaskManager(Base_TaskManager):
                                                  routing_key=self._hb_response_q,
                                                  properties=nprops,
                                                  body='response')
-                    except pika.exceptions.ConnectionClosed:
+                    except (pika.exceptions.ConnectionClosed,
+                            pika.exceptions.ChannelClosed):
                         connection = pika.BlockingConnection(conn_params)
                         channel = connection.channel()
                         nprops = pika.BasicProperties(
@@ -268,7 +269,8 @@ class TaskManager(Base_TaskManager):
                         channel.basic_publish(exchange='',
                                                  routing_key='%s-completedq-1' % self._sid,
                                                  body=task_as_dict)
-                    except pika.exceptions.ConnectionClosed:
+                    except (pika.exceptions.ConnectionClosed,
+                            pika.exceptions.ChannelClosed):
                         connection = pika.BlockingConnection(conn_params)
                         channel = connection.channel()
                         channel.basic_publish(exchange='',

--- a/tests/test_component/test_tmgr_base.py
+++ b/tests/test_component/test_tmgr_base.py
@@ -107,9 +107,9 @@ class TestBase(TestCase):
 
         global_syncs = []
 
-        def _sync_side_effect(log_entry, uid, state, msg):
+        def _sync_side_effect(obj, obj_type, channel, conn_params, queue):
             nonlocal global_syncs
-            global_syncs.append([log_entry, uid, state, msg])
+            global_syncs.append([obj, obj_type, channel, conn_params, queue])
 
         tmgr._log = mocked_Logger
         tmgr._prof = mocked_Profiler
@@ -120,12 +120,13 @@ class TestBase(TestCase):
         obj.parent_pipeline = {'uid': 'test_pipe'}
         obj.uid = 'test_object'
         obj.state = 'test_state'
-        tmgr._advance(obj, 'Task', None, 'channel','queue')
-        self.assertEqual(global_syncs[0],[obj, 'Task', 'channel','queue'])
+        tmgr._advance(obj, 'Task', None, 'channel','params','queue')
+        self.assertEqual(global_syncs[0],[obj, 'Task', 'channel', 'params', 'queue'])
         self.assertIsNone(obj.state)
         global_syncs = []
-        tmgr._advance(obj, 'Stage', 'new_state', 'channel','queue')
-        self.assertEqual(global_syncs[0],[obj, 'Stage', 'channel','queue'])
+        tmgr._advance(obj, 'Stage', 'new_state', 'channel', 'params', 'queue')
+        self.assertEqual(global_syncs[0],[obj, 'Stage', 'channel', 'params', 
+                                          'queue'])
         self.assertEqual(obj.state, 'new_state')
 
     # ------------------------------------------------------------------------------

--- a/tests/test_component/test_tmgr_rp.py
+++ b/tests/test_component/test_tmgr_rp.py
@@ -66,7 +66,7 @@ class TestBase(TestCase):
         tmgr._prof = mocked_Profiler
         tmgr._uid = 'tmgr.0000'
         tmgr._rmgr = 'test_rmgr'
-        tmgr._rmq_conn_params = 'test_params'
+        tmgr._rmq_conn_params = rmq_params
         tmgr._pending_queue = ['pending_queues']
         tmgr._completed_queue = ['completed_queues']
         tmgr._tmgr = _tmgr_side_effect

--- a/tests/test_integration/test_tmgr_base/test_heartbeat.py
+++ b/tests/test_integration/test_tmgr_base/test_heartbeat.py
@@ -2,7 +2,6 @@
 # pylint: disable=no-value-for-parameter
 import os
 import pika
-import json
 import time
 
 from unittest import TestCase, mock
@@ -51,7 +50,7 @@ class TestTask(TestCase):
         time.sleep(0.1)
         body = None
         try:
-            for i in range(5):
+            for _ in range(5):
                 while body is None:
                     _, props, body = mq_channel.basic_get(queue='tmgr-hb-request')
                 self.assertEqual(body, b'request')

--- a/tests/test_integration/test_tmgr_base/test_heartbeat.py
+++ b/tests/test_integration/test_tmgr_base/test_heartbeat.py
@@ -1,0 +1,100 @@
+# pylint: disable=protected-access, unused-argument
+# pylint: disable=no-value-for-parameter
+import os
+import pika
+import json
+import time
+
+from unittest import TestCase, mock
+
+import threading as mt
+import radical.utils as ru
+
+from radical.entk.execman.base import Base_TaskManager as BaseTmgr
+
+
+# ------------------------------------------------------------------------------
+#
+class TestTask(TestCase):
+
+    # --------------------------------------------------------------------------
+    #
+    @mock.patch.object(BaseTmgr, '__init__',   return_value=None)
+    @mock.patch('radical.utils.Profiler')
+    def test_heartbeat(self, mocked_init, mocked_Profiler):
+
+        hostname = os.environ.get('RMQ_HOSTNAME', 'localhost')
+        port = int(os.environ.get('RMQ_PORT', '5672'))
+        username = os.environ.get('RMQ_USERNAME','guest')
+        password = os.environ.get('RMQ_PASSWORD','guest')
+        credentials = pika.PlainCredentials(username, password)
+        rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port,
+                                                    credentials=credentials)
+        tmgr = BaseTmgr(None, None, None, None, None, None)
+        tmgr._uid = 'tmgr.0000'
+        tmgr._log = ru.Logger('radical.entk.manager.base', level='DEBUG')
+        tmgr._prof = mocked_Profiler
+        tmgr._hb_interval = 0.1
+        tmgr._hb_terminate = mt.Event()
+        tmgr._hb_request_q = 'tmgr-hb-request'
+        tmgr._hb_response_q = 'tmgr-hb-response'
+        tmgr._rmq_conn_params = rmq_conn_params
+        mq_connection = pika.BlockingConnection(rmq_conn_params)
+        mq_channel = mq_connection.channel()
+        mq_channel.queue_declare(queue='tmgr-hb-request')
+        mq_channel.queue_declare(queue='tmgr-hb-response')
+        tmgr._log.info('Starting test')
+        master_thread = mt.Thread(target=tmgr._heartbeat,
+                                  name='tmgr_heartbeat')
+
+        master_thread.start()
+        time.sleep(0.1)
+        body = None
+        try:
+            for i in range(5):
+                while body is None:
+                    _, props, body = mq_channel.basic_get(queue='tmgr-hb-request')
+                self.assertEqual(body, b'request')
+                nprops = pika.BasicProperties(correlation_id=props.correlation_id)
+                mq_channel.basic_publish(exchange='',
+                                         routing_key='tmgr-hb-response',
+                                         properties=nprops,
+                                         body='response')
+                self.assertTrue(master_thread.is_alive())
+                body = None
+
+            time.sleep(0.5)
+            self.assertFalse(master_thread.is_alive())
+            master_thread.join()
+            mq_channel.queue_delete(queue='tmgr-hb-request')
+            mq_channel.queue_delete(queue='tmgr-hb-response')
+            mq_channel.queue_declare(queue='tmgr-hb-request')
+            mq_channel.queue_declare(queue='tmgr-hb-response')
+
+            master_thread = mt.Thread(target=tmgr._heartbeat,
+                                      name='tmgr_heartbeat')
+            master_thread.start()
+            body = None
+            while body is None:
+                _, props, body = mq_channel.basic_get(queue='tmgr-hb-request')
+            mq_channel.basic_publish(exchange='',
+                                     routing_key='tmgr-hb-response',
+                                     body='response')
+            time.sleep(0.2)
+            self.assertFalse(master_thread.is_alive())
+
+        except Exception as ex:
+            tmgr._hb_terminate.set()
+            master_thread.join()
+            mq_channel.queue_delete(queue='tmgr-hb-request')
+            mq_channel.queue_delete(queue='tmgr-hb-response')
+            mq_channel.close()
+            mq_connection.close()
+            raise ex
+        else:
+            tmgr._hb_terminate.set()
+            master_thread.join()
+            mq_channel.queue_delete(queue='tmgr-hb-request')
+            mq_channel.queue_delete(queue='tmgr-hb-response')
+            mq_channel.close()
+            mq_connection.close()

--- a/tests/test_integration/test_tmgr_base/test_sync_with_master.py
+++ b/tests/test_integration/test_tmgr_base/test_sync_with_master.py
@@ -6,7 +6,7 @@ import json
 import time
 
 from unittest import TestCase, mock
-import multiprocessing as mp
+import threading as mt
 
 from radical.entk              import Task, Stage
 from radical.entk.execman.base import Base_TaskManager     as BaseTmgr
@@ -30,13 +30,13 @@ class TestTask(TestCase):
             tmgr = BaseTmgr(None, None, None, None, None, None)
             tmgr._log = mocked_Logger
             tmgr._prof = mocked_Profiler
-            mq_connection = pika.BlockingConnection(rmq_conn_params)
-            mq_channel = mq_connection.channel()
+            mq_connection2 = pika.BlockingConnection(rmq_conn_params)
+            mq_channel2 = mq_connection.channel()
             for obj_type, obj, in packets:
-                tmgr._sync_with_master(obj, obj_type, mq_channel, conn_params,
+                tmgr._sync_with_master(obj, obj_type, mq_channel2, conn_params,
                                        queue)
-                if mq_channel.is_open:
-                    mq_channel.close()
+                if mq_channel2.is_open:
+                    mq_channel2.close()
 
         task = Task()
         task.parent_stage = {'uid':'stage.0000', 'name': 'stage.0000'}
@@ -54,7 +54,7 @@ class TestTask(TestCase):
         mq_connection = pika.BlockingConnection(rmq_conn_params)
         mq_channel = mq_connection.channel()
         mq_channel.queue_declare(queue='master')
-        master_thread = mp.Process(target=component_execution,
+        master_thread = mt.Thread(target=component_execution,
                                   name='tmgr_sync', 
                                   args=(packets, rmq_conn_params, 'master'))
         master_thread.start()

--- a/tests/test_integration/test_tmgr_base/test_sync_with_master.py
+++ b/tests/test_integration/test_tmgr_base/test_sync_with_master.py
@@ -65,6 +65,7 @@ class TestTask(TestCase):
                 msg = json.loads(body)
                 self.assertEqual(msg['object'], packet[1].to_dict())
                 self.assertEqual(msg['type'], packet[0])
+                time.sleep(200)
         except Exception as ex:
             print(body)
             print(json.loads(body))

--- a/tests/test_integration/test_tmgr_base/test_sync_with_master.py
+++ b/tests/test_integration/test_tmgr_base/test_sync_with_master.py
@@ -25,10 +25,12 @@ class TestTask(TestCase):
 
         # --------------------------------------------------------------------------
         #
-        def component_execution(inputs, method, channel, queue):
+        def component_execution(inputs, method, channel, conn_params, queue):
 
             for obj_type, obj, in inputs:
-                method(obj, obj_type, channel, queue)
+                method(obj, obj_type, channel, conn_params, queue)
+                if channel.is_open:
+                    channel.close()
             return True
 
 
@@ -65,7 +67,6 @@ class TestTask(TestCase):
                 msg = json.loads(body)
                 self.assertEqual(msg['object'], packet[1].to_dict())
                 self.assertEqual(msg['type'], packet[0])
-                time.sleep(200)
         except Exception as ex:
             print(body)
             print(json.loads(body))

--- a/tests/test_integration/test_tmgr_base/test_sync_with_master.py
+++ b/tests/test_integration/test_tmgr_base/test_sync_with_master.py
@@ -31,7 +31,7 @@ class TestTask(TestCase):
             tmgr._log = mocked_Logger
             tmgr._prof = mocked_Profiler
             mq_connection2 = pika.BlockingConnection(rmq_conn_params)
-            mq_channel2 = mq_connection.channel()
+            mq_channel2 = mq_connection2.channel()
             for obj_type, obj, in packets:
                 tmgr._sync_with_master(obj, obj_type, mq_channel2, conn_params,
                                        queue)

--- a/tests/test_integration/test_tmgr_base/test_sync_with_master.py
+++ b/tests/test_integration/test_tmgr_base/test_sync_with_master.py
@@ -22,7 +22,7 @@ class TestTask(TestCase):
     @mock.patch('radical.utils.Logger')
     @mock.patch('radical.utils.Profiler')
     def test_sync_with_master(self, mocked_init, mocked_Logger, mocked_Profiler):
-        self.maxDiff = None
+
         # --------------------------------------------------------------------------
         #
         def component_execution(packets, conn_params, queue):

--- a/tests/test_integration/test_tmgr_base/test_sync_with_master.py
+++ b/tests/test_integration/test_tmgr_base/test_sync_with_master.py
@@ -6,7 +6,7 @@ import json
 import time
 
 from unittest import TestCase, mock
-import threading as mt
+import multiprocessing as mp
 
 from radical.entk              import Task, Stage
 from radical.entk.execman.base import Base_TaskManager     as BaseTmgr
@@ -22,44 +22,44 @@ class TestTask(TestCase):
     @mock.patch('radical.utils.Logger')
     @mock.patch('radical.utils.Profiler')
     def test_sync_with_master(self, mocked_init, mocked_Logger, mocked_Profiler):
-
+        self.maxDiff = None
         # --------------------------------------------------------------------------
         #
-        def component_execution(inputs, method, channel, conn_params, queue):
+        def component_execution(packets, conn_params, queue):
 
-            for obj_type, obj, in inputs:
-                method(obj, obj_type, channel, conn_params, queue)
-                if channel.is_open:
-                    channel.close()
-            return True
-
+            tmgr = BaseTmgr(None, None, None, None, None, None)
+            tmgr._log = mocked_Logger
+            tmgr._prof = mocked_Profiler
+            mq_connection = pika.BlockingConnection(rmq_conn_params)
+            mq_channel = mq_connection.channel()
+            for obj_type, obj, in packets:
+                tmgr._sync_with_master(obj, obj_type, mq_channel, conn_params,
+                                       queue)
+                if mq_channel.is_open:
+                    mq_channel.close()
 
         task = Task()
         task.parent_stage = {'uid':'stage.0000', 'name': 'stage.0000'}
-        hostname = os.environ.get('RMQ_HOSTNAME', 'localhost')
-        port = int(os.environ.get('RMQ_PORT', '5672'))
-        username = os.environ.get('RMQ_USERNAME','guest')
-        password = os.environ.get('RMQ_PASSWORD','guest')
         packets = [('Task', task)]
         stage = Stage()
         stage.parent_pipeline = {'uid':'pipe.0000', 'name': 'pipe.0000'}
         packets.append(('Stage', stage))
+        hostname = os.environ.get('RMQ_HOSTNAME', 'localhost')
+        port = int(os.environ.get('RMQ_PORT', '5672'))
+        username = os.environ.get('RMQ_USERNAME','guest')
+        password = os.environ.get('RMQ_PASSWORD','guest')
         credentials = pika.PlainCredentials(username, password)
         rmq_conn_params = pika.ConnectionParameters(host=hostname, port=port,
                 credentials=credentials)
         mq_connection = pika.BlockingConnection(rmq_conn_params)
         mq_channel = mq_connection.channel()
         mq_channel.queue_declare(queue='master')
-        tmgr = BaseTmgr(None, None, None, None, None, None)
-        tmgr._log = mocked_Logger
-        tmgr._prof = mocked_Profiler
-
-        master_thread = mt.Thread(target=component_execution,
+        master_thread = mp.Process(target=component_execution,
                                   name='tmgr_sync', 
-                                  args=(packets, tmgr._sync_with_master,
-                                  mq_channel, 'master'))
+                                  args=(packets, rmq_conn_params, 'master'))
         master_thread.start()
-        time.sleep(0.1)
+
+        time.sleep(1)
         try:
             while packets:
                 packet = packets.pop(0)
@@ -68,7 +68,7 @@ class TestTask(TestCase):
                 self.assertEqual(msg['object'], packet[1].to_dict())
                 self.assertEqual(msg['type'], packet[0])
         except Exception as ex:
-            print(body)
+            print(ex)
             print(json.loads(body))
             master_thread.join()
             mq_channel.queue_delete(queue='master')


### PR DESCRIPTION
This PR fixes the connection closed exception we were getting for long-running tasks. When the connection or the channel is closed, we receive an exception from pika. We then handle that exception by creating a new connection and channel and send the message again.

Unfortunately, we cannot know the actual RMQ server state for a connection or channel through their `is_open` or `is_closed` methods.

Although there is a replication in the messaging code, we avoid the overhead of creating a new connection and channel for every message.