### PR TITLE
Using  RPs tags instead of tag

### DIFF
--- a/src/radical/entk/execman/rp/task_processor.py
+++ b/src/radical/entk/execman/rp/task_processor.py
@@ -473,9 +473,9 @@ def create_td_from_task(task, placeholders, task_hash_table, pkl_path, sid,
         td.stage_on_error = task.stage_on_error
 
         if task.parent_pipeline['uid']:
-            td.tag = resolve_tags(task=task,
+            td.tags = {'colocate': resolve_tags(task=task,
                                   parent_pipeline_name=task.parent_pipeline['uid'],
-                                  placeholders=placeholders)
+                                  placeholders=placeholders)}
 
         td.cpu_processes    = task.cpu_reqs['cpu_processes']
         td.cpu_threads      = task.cpu_reqs['cpu_threads']

--- a/src/radical/entk/execman/rp/task_processor.py
+++ b/src/radical/entk/execman/rp/task_processor.py
@@ -175,7 +175,7 @@ def resolve_tags(task, parent_pipeline_name, placeholders):
     # Check self pipeline first
     for sname in placeholders[parent_pipeline_name]:
         if colo_tag in placeholders[parent_pipeline_name][sname]:
-            return placeholders[parent_pipeline_name][sname][colo_tag]['uid']
+            return {'colocate': placeholders[parent_pipeline_name][sname][colo_tag]['uid']}
 
     for pname in placeholders:
 
@@ -185,9 +185,9 @@ def resolve_tags(task, parent_pipeline_name, placeholders):
 
         for sname in placeholders[pname]:
             if colo_tag in placeholders[pname][sname]:
-                return placeholders[pname][sname][colo_tag]['uid']
+                return {'colocate': placeholders[pname][sname][colo_tag]['uid']}
 
-    return task.uid
+    return {'colocate': task.uid}
 
 
 # ------------------------------------------------------------------------------
@@ -473,9 +473,9 @@ def create_td_from_task(task, placeholders, task_hash_table, pkl_path, sid,
         td.stage_on_error = task.stage_on_error
 
         if task.parent_pipeline['uid']:
-            td.tags = {'colocate': resolve_tags(task=task,
+            td.tags = resolve_tags(task=task,
                                   parent_pipeline_name=task.parent_pipeline['uid'],
-                                  placeholders=placeholders)}
+                                  placeholders=placeholders)
 
         td.cpu_processes    = task.cpu_reqs['cpu_processes']
         td.cpu_threads      = task.cpu_reqs['cpu_threads']

--- a/tests/test_component/test_tproc_rp.py
+++ b/tests/test_component/test_tproc_rp.py
@@ -122,14 +122,15 @@ class TestBase(TestCase):
         }
 
 
-
-        self.assertEqual(resolve_tags(task=task,
+        tags = resolve_tags(task=task,
                             parent_pipeline_name=pipeline_name,
-                            placeholders=placeholders),
-                            'unit.0002')
+                            placeholders=placeholders)
+        print(tags)
+        self.assertEqual(tags,
+                         {'colocate': 'unit.0002'})
 
         self.assertEqual(resolve_tags(task=task2, parent_pipeline_name=pipeline_name,
-                         placeholders=placeholders), 'task.0001')
+                         placeholders=placeholders), {'colocate':'task.0001'})
 
     # ------------------------------------------------------------------------------
     #
@@ -216,10 +217,9 @@ class TestBase(TestCase):
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
         self.assertEqual(test_td.output_staging, 'outputs')
-        self.assertEqual(test_td.tags, {'colocate': 'test_tag'})
+        self.assertEqual(test_td.tags, 'test_tag')
         self.assertEqual(test_td.uid, 'task.0000')
         self.assertEqual(hash_table, {'task.0000':'task.0000'})
-
 
         test_td = create_td_from_task(task=task, placeholders=None,
                                       task_hash_table=hash_table,
@@ -244,7 +244,7 @@ class TestBase(TestCase):
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
         self.assertEqual(test_td.output_staging, 'outputs')
-        self.assertEqual(test_td.tags, {'colocate': 'test_tag'})
+        self.assertEqual(test_td.tags, 'test_tag')
         self.assertEqual(test_td.uid, 'task.0000.0000')
         self.assertEqual(hash_table, {'task.0000':'task.0000.0000'})
 

--- a/tests/test_component/test_tproc_rp.py
+++ b/tests/test_component/test_tproc_rp.py
@@ -216,7 +216,7 @@ class TestBase(TestCase):
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
         self.assertEqual(test_td.output_staging, 'outputs')
-        self.assertEqual(test_td.tag, 'test_tag')
+        self.assertEqual(test_td.tags, {'colocate': 'test_tag'})
         self.assertEqual(test_td.uid, 'task.0000')
         self.assertEqual(hash_table, {'task.0000':'task.0000'})
 
@@ -244,7 +244,7 @@ class TestBase(TestCase):
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
         self.assertEqual(test_td.output_staging, 'outputs')
-        self.assertEqual(test_td.tag, 'test_tag')
+        self.assertEqual(test_td.tags, {'colocate': 'test_tag'})
         self.assertEqual(test_td.uid, 'task.0000.0000')
         self.assertEqual(hash_table, {'task.0000':'task.0000.0000'})
 

--- a/tests/test_component/test_tproc_rp.py
+++ b/tests/test_component/test_tproc_rp.py
@@ -214,7 +214,6 @@ class TestBase(TestCase):
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
         self.assertEqual(test_td.output_staging, 'outputs')
-        self.assertEqual(test_td.tags, 'test_tag')
         self.assertEqual(test_td.uid, 'task.0000')
         self.assertEqual(hash_table, {'task.0000':'task.0000'})
 
@@ -241,7 +240,6 @@ class TestBase(TestCase):
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
         self.assertEqual(test_td.output_staging, 'outputs')
-        self.assertEqual(test_td.tags, 'test_tag')
         self.assertEqual(test_td.uid, 'task.0000.0000')
         self.assertEqual(hash_table, {'task.0000':'task.0000.0000'})
 

--- a/tests/test_component/test_tproc_rp.py
+++ b/tests/test_component/test_tproc_rp.py
@@ -121,12 +121,9 @@ class TestBase(TestCase):
             }
         }
 
-
-        tags = resolve_tags(task=task,
+        self.assertEqual(resolve_tags(task=task,
                             parent_pipeline_name=pipeline_name,
-                            placeholders=placeholders)
-        print(tags)
-        self.assertEqual(tags,
+                            placeholders=placeholders),
                          {'colocate': 'unit.0002'})
 
         self.assertEqual(resolve_tags(task=task2, parent_pipeline_name=pipeline_name,

--- a/tests/test_integration/test_tmgr_rp/test_tproc_rp.py
+++ b/tests/test_integration/test_tmgr_rp/test_tproc_rp.py
@@ -81,13 +81,13 @@ class TestBase(TestCase):
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, [])
         self.assertEqual(test_td.output_staging, [])
-        self.assertEqual(test_td.tag, 'task.0000')
+        self.assertEqual(test_td.tags, {'colocate':'task.0000'})
         self.assertEqual(test_td.uid,'task.0000')
         self.assertEqual(hash_table, {'task.0000': 'task.0000'})
         task.tags = {'colocate': 'task.0001'}
         test_td = create_td_from_task(task, placeholders, hash_table,
                                       '.test.pkl', 'test_sid')
-        self.assertEqual(test_td.tag, 'task.0003')
+        self.assertEqual(test_td.tags, {'colocate':'task.0003'})
         self.assertEqual(test_td.uid, 'task.0000.0000')
         self.assertEqual(hash_table, {'task.0000': 'task.0000.0000'})
         with open('.test.pkl', 'rb') as f:


### PR DESCRIPTION
I updated RE's integration with RP. Instead of `tag` for tagging tasks RE now uses `tags`.

Thank you