### PR TITLE
RP task processor adds default values to RP task cpu and gpu reqs

### DIFF
--- a/src/radical/entk/execman/rp/task_processor.py
+++ b/src/radical/entk/execman/rp/task_processor.py
@@ -479,12 +479,27 @@ def create_td_from_task(task, placeholders, task_hash_table, pkl_path, sid,
 
         td.cpu_processes    = task.cpu_reqs['cpu_processes']
         td.cpu_threads      = task.cpu_reqs['cpu_threads']
-        td.cpu_process_type = task.cpu_reqs['cpu_process_type']
-        td.cpu_thread_type  = task.cpu_reqs['cpu_thread_type']
+        if task.cpu_reqs['cpu_process_type']:
+            td.cpu_process_type = task.cpu_reqs['cpu_process_type']
+        else:
+            td.cpu_process_type = rp.POSIX
+
+        if task.cpu_reqs['cpu_thread_type']:
+            td.cpu_thread_type = task.cpu_reqs['cpu_thread_type']
+        else:
+            td.cpu_thread_type = rp.OpenMP
+
         td.gpu_processes    = task.gpu_reqs['gpu_processes']
         td.gpu_threads      = task.gpu_reqs['gpu_threads']
-        td.gpu_process_type = task.gpu_reqs['gpu_process_type']
-        td.gpu_thread_type  = task.gpu_reqs['gpu_thread_type']
+
+        if task.gpu_reqs['gpu_process_type']:
+            td.gpu_process_type = task.gpu_reqs['gpu_process_type']
+        else:
+            td.gpu_process_type = rp.POSIX
+        if task.gpu_reqs['gpu_thread_type']:
+            td.gpu_thread_type = task.gpu_reqs['gpu_thread_type']
+        else:
+            td.gpu_thread_type = rp.GPU_OpenMP
 
         if task.lfs_per_process:
             td.lfs_per_process = task.lfs_per_process

--- a/tests/test_component/test_tproc_rp.py
+++ b/tests/test_component/test_tproc_rp.py
@@ -179,12 +179,12 @@ class TestBase(TestCase):
         task.post_exec = ''
         task.cpu_reqs = {'cpu_processes': 5,
                          'cpu_threads': 6,
-                         'cpu_process_type': 'POSIX',
-                         'cpu_thread_type': None}
+                         'cpu_process_type': 'MPI',
+                         'cpu_thread_type': 'MPI'}
         task.gpu_reqs = {'gpu_processes': 5,
                          'gpu_threads': 6,
-                         'gpu_process_type': 'POSIX',
-                         'gpu_thread_type': None}
+                         'gpu_process_type': 'MPI',
+                         'gpu_thread_type': 'MPI'}
         task.tags = None
 
         task.lfs_per_process = 235
@@ -203,12 +203,12 @@ class TestBase(TestCase):
         self.assertEqual(test_td.post_exec, '')
         self.assertEqual(test_td.cpu_processes, 5)
         self.assertEqual(test_td.cpu_threads, 6)
-        self.assertEqual(test_td.cpu_process_type, 'POSIX')
-        self.assertIsNone(test_td.cpu_thread_type)
+        self.assertEqual(test_td.cpu_process_type, 'MPI')
+        self.assertEqual(test_td.cpu_thread_type, 'MPI')
         self.assertEqual(test_td.gpu_processes, 5)
         self.assertEqual(test_td.gpu_threads, 6)
-        self.assertEqual(test_td.gpu_process_type, 'POSIX')
-        self.assertIsNone(test_td.gpu_thread_type)
+        self.assertEqual(test_td.gpu_process_type, 'MPI')
+        self.assertEqual(test_td.gpu_thread_type, 'MPI')
         self.assertEqual(test_td.lfs_per_process, 235)
         self.assertEqual(test_td.stdout, 'stdout')
         self.assertEqual(test_td.stderr, 'stderr')
@@ -216,6 +216,15 @@ class TestBase(TestCase):
         self.assertEqual(test_td.output_staging, 'outputs')
         self.assertEqual(test_td.uid, 'task.0000')
         self.assertEqual(hash_table, {'task.0000':'task.0000'})
+
+        task.cpu_reqs = {'cpu_processes': 5,
+                         'cpu_threads': 6,
+                         'cpu_process_type': None,
+                         'cpu_thread_type': None}
+        task.gpu_reqs = {'gpu_processes': 5,
+                         'gpu_threads': 6,
+                         'gpu_process_type': None,
+                         'gpu_thread_type': None}
 
         test_td = create_td_from_task(task=task, placeholders=None,
                                       task_hash_table=hash_table,
@@ -230,11 +239,11 @@ class TestBase(TestCase):
         self.assertEqual(test_td.cpu_processes, 5)
         self.assertEqual(test_td.cpu_threads, 6)
         self.assertEqual(test_td.cpu_process_type, 'POSIX')
-        self.assertIsNone(test_td.cpu_thread_type)
+        self.assertEqual(test_td.cpu_thread_type, 'OpenMP')
         self.assertEqual(test_td.gpu_processes, 5)
         self.assertEqual(test_td.gpu_threads, 6)
         self.assertEqual(test_td.gpu_process_type, 'POSIX')
-        self.assertIsNone(test_td.gpu_thread_type)
+        self.assertEqual(test_td.gpu_thread_type, 'GPU_OpenMP')
         self.assertEqual(test_td.lfs_per_process, 235)
         self.assertEqual(test_td.stdout, 'stdout')
         self.assertEqual(test_td.stderr, 'stderr')
@@ -546,11 +555,11 @@ class TestBase(TestCase):
         self.assertEqual(test_cud.cpu_processes, 5)
         self.assertEqual(test_cud.cpu_threads, 6)
         self.assertEqual(test_cud.cpu_process_type, 'POSIX')
-        self.assertIsNone(test_cud.cpu_thread_type)
+        self.assertEqual(test_cud.cpu_thread_type, 'OpenMP')
         self.assertEqual(test_cud.gpu_processes, 5)
         self.assertEqual(test_cud.gpu_threads, 6)
         self.assertEqual(test_cud.gpu_process_type, 'POSIX')
-        self.assertIsNone(test_cud.gpu_thread_type)
+        self.assertEqual(test_cud.gpu_thread_type, 'GPU_OpenMP')
         self.assertEqual(test_cud.lfs_per_process, 235)
         self.assertEqual(test_cud.stdout, 'stdout')
         self.assertEqual(test_cud.stderr, 'stderr')

--- a/tests/test_integration/test_tmgr_rp/test_tproc_rp.py
+++ b/tests/test_integration/test_tmgr_rp/test_tproc_rp.py
@@ -9,6 +9,7 @@ from radical.entk                           import Task
 import pickle
 import radical.pilot as rp
 
+
 class TestBase(TestCase):
 
     # ------------------------------------------------------------------------------

--- a/tests/test_integration/test_tmgr_rp/test_tproc_rp.py
+++ b/tests/test_integration/test_tmgr_rp/test_tproc_rp.py
@@ -7,7 +7,7 @@ from radical.entk.execman.rp.task_processor import create_td_from_task
 from radical.entk                           import Task
 
 import pickle
-
+import radical.pilot as rp
 
 class TestBase(TestCase):
 
@@ -62,6 +62,7 @@ class TestBase(TestCase):
         hash_table = {}
         test_td = create_td_from_task(task, placeholders, hash_table,
                                       '.test.pkl', 'test_sid')
+        self.assertIsInstance(test_td, rp.TaskDescription)
         self.assertEqual(test_td.name, 'task.0000,task.0000,stage.0000,stage.0000,pipe.0000,pipe.0000')
         self.assertEqual(test_td.pre_exec, ['post_exec'])
         self.assertEqual(test_td.executable, '/bin/date')
@@ -70,12 +71,12 @@ class TestBase(TestCase):
         self.assertEqual(test_td.post_exec, [''])
         self.assertEqual(test_td.cpu_processes, 5)
         self.assertEqual(test_td.cpu_threads, 6)
-        self.assertEqual(test_td.cpu_process_type, 'MPI')
-        self.assertIsNone(test_td.cpu_thread_type)
+        self.assertEqual(test_td.cpu_process_type, rp.MPI)
+        self.assertEqual(test_td.cpu_thread_type, rp.OpenMP)
         self.assertEqual(test_td.gpu_processes, 5)
         self.assertEqual(test_td.gpu_threads, 6)
-        self.assertEqual(test_td.gpu_process_type, None)
-        self.assertIsNone(test_td.gpu_thread_type)
+        self.assertEqual(test_td.gpu_process_type, rp.POSIX)
+        self.assertEqual(test_td.gpu_thread_type, rp.GPU_OpenMP)
         self.assertEqual(test_td.lfs_per_process, 235)
         self.assertEqual(test_td.stdout, 'stdout')
         self.assertEqual(test_td.stderr, 'stderr')


### PR DESCRIPTION
RP's scheduler does not like `None` values for process and thread types. This PR makes sure that posix and openmp are used as the default values when RP is used as the RTS. Since RE can use any type of RTS, it did not make sense to me to make the `task` default values.