### PR TITLE
'base_path' param introduced in AppManager to change default directory of logger and profiler

### DIFF
--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -76,7 +76,7 @@ class AppManager(object):
                  rmq_cleanup=None,
                  rts_config=None,
                  name=None,
-                 config={}):
+                 config=None):
 
         # Create a session for each EnTK script execution
         if name:
@@ -85,6 +85,9 @@ class AppManager(object):
         else:
             self._name = str()
             self._sid  = ru.generate_id('re.session', ru.ID_PRIVATE)
+
+        if config is None:
+            config = dict()
 
         self._read_config(config_path, hostname, port, username, password,
                           reattempts, resubmit_failed, autoterminate,
@@ -147,8 +150,8 @@ class AppManager(object):
 
         config = ru.read_json(os.path.join(config_path, 'config.json'))
 
-        # config_params (2nd dictionary) overwrites values if duplicated
-        config = { **config, **config_params }
+        # config_params overwrites values if duplicated
+        config.update(config_params)
 
         def _if(val1, val2):
             if val1 is not None: return val1

--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -154,7 +154,7 @@ class AppManager(object):
             if val1 is not None: return val1
             else               : return val2
 
-        self._path             = config.get('base_path', os.getcwd())
+        self._path             = str(config.get('base_path', os.getcwd()))
         self._hostname         = _if(hostname,        config['hostname'])
         self._port             = _if(port,            config['port'])
         self._username         = _if(username,        config['username'])

--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -58,6 +58,8 @@ class AppManager(object):
                           True/False} when RTS is RP
         :name:            Name of the Application. It should be unique between
                           executions. (default is randomly assigned)
+        :base_path:       base path of logger and profiler with a session id,
+                          None (default) will use a current working directory
     '''
 
     # --------------------------------------------------------------------------
@@ -76,7 +78,7 @@ class AppManager(object):
                  rmq_cleanup=None,
                  rts_config=None,
                  name=None,
-                 config=None):
+                 base_path=None):
 
         # Create a session for each EnTK script execution
         if name:
@@ -86,20 +88,17 @@ class AppManager(object):
             self._name = str()
             self._sid  = ru.generate_id('re.session', ru.ID_PRIVATE)
 
-        if config is None:
-            config = dict()
-
         self._read_config(config_path, hostname, port, username, password,
                           reattempts, resubmit_failed, autoterminate,
                           write_workflow, rts, rmq_cleanup, rts_config,
-                          config)
+                          base_path)
 
         # Create an uid + logger + profiles for AppManager, under the sid
         # namespace
 
         self._uid = ru.generate_id('appmanager.%(counter)04d', ru.ID_CUSTOM)
 
-        path = self._path + '/' + self._sid
+        path = str(self._base_path) + '/' + self._sid
         name = 'radical.entk.%s' % self._uid
 
         self._logger = ru.Logger(name=name, path=path)
@@ -143,21 +142,18 @@ class AppManager(object):
     #
     def _read_config(self, config_path, hostname, port, username, password,
                      reattempts, resubmit_failed, autoterminate,
-                     write_workflow, rts, rmq_cleanup, rts_config, config_params):
+                     write_workflow, rts, rmq_cleanup, rts_config, base_path):
 
         if not config_path:
             config_path = os.path.dirname(os.path.abspath(__file__))
 
         config = ru.read_json(os.path.join(config_path, 'config.json'))
 
-        # config_params overwrites values if duplicated
-        config.update(config_params)
-
         def _if(val1, val2):
             if val1 is not None: return val1
             else               : return val2
 
-        self._path             = str(config.get('base_path', os.getcwd()))
+        self._base_path        = _if(base_path,       os.getcwd())
         self._hostname         = _if(hostname,        config['hostname'])
         self._port             = _if(port,            config['port'])
         self._username         = _if(username,        config['username'])

--- a/src/radical/entk/appman/appmanager.py
+++ b/src/radical/entk/appman/appmanager.py
@@ -75,7 +75,8 @@ class AppManager(object):
                  rts=None,
                  rmq_cleanup=None,
                  rts_config=None,
-                 name=None):
+                 name=None,
+                 config={}):
 
         # Create a session for each EnTK script execution
         if name:
@@ -87,14 +88,15 @@ class AppManager(object):
 
         self._read_config(config_path, hostname, port, username, password,
                           reattempts, resubmit_failed, autoterminate,
-                          write_workflow, rts, rmq_cleanup, rts_config)
+                          write_workflow, rts, rmq_cleanup, rts_config,
+                          config)
 
         # Create an uid + logger + profiles for AppManager, under the sid
         # namespace
 
         self._uid = ru.generate_id('appmanager.%(counter)04d', ru.ID_CUSTOM)
 
-        path = os.getcwd() + '/' + self._sid
+        path = self._path + '/' + self._sid
         name = 'radical.entk.%s' % self._uid
 
         self._logger = ru.Logger(name=name, path=path)
@@ -138,17 +140,21 @@ class AppManager(object):
     #
     def _read_config(self, config_path, hostname, port, username, password,
                      reattempts, resubmit_failed, autoterminate,
-                     write_workflow, rts, rmq_cleanup, rts_config):
+                     write_workflow, rts, rmq_cleanup, rts_config, config_params):
 
         if not config_path:
             config_path = os.path.dirname(os.path.abspath(__file__))
 
         config = ru.read_json(os.path.join(config_path, 'config.json'))
 
+        # config_params (2nd dictionary) overwrites values if duplicated
+        config = { **config, **config_params }
+
         def _if(val1, val2):
             if val1 is not None: return val1
             else               : return val2
 
+        self._path             = config.get('base_path', os.getcwd())
         self._hostname         = _if(hostname,        config['hostname'])
         self._port             = _if(port,            config['port'])
         self._username         = _if(username,        config['username'])

--- a/tests/test_component/test_amgr.py
+++ b/tests/test_component/test_amgr.py
@@ -62,7 +62,8 @@ class TestBase(TestCase):
                           write_workflow=None,
                           rts=None,
                           rmq_cleanup=None,
-                          rts_config=None)
+                          rts_config=None,
+                          base_path=None)
 
         self.assertEqual(amgr._hostname ,d['hostname'])
         self.assertEqual(amgr._port ,d['port'])
@@ -91,7 +92,8 @@ class TestBase(TestCase):
                               write_workflow=None,
                               rts=None,
                               rmq_cleanup=None,
-                              rts_config=None)
+                              rts_config=None,
+                              base_path=None)
 
 
     # ------------------------------------------------------------------------------
@@ -129,7 +131,8 @@ class TestBase(TestCase):
                           rmq_cleanup=d2['rmq_cleanup'],
                           rts="mock",
                           rts_config={"sandbox_cleanup": True,
-                                      "db_cleanup"     : True})
+                                      "db_cleanup"     : True},
+                          base_path=None)
 
         self.assertEqual(amgr._hostname, d2['hostname'])
         self.assertEqual(amgr._port, d2['port'])


### PR DESCRIPTION
To address #589 , AppManager takes `config` param, python dictionary, to change default value such as base path for logger and profiler.