### PR TITLE
adding mem_per_process entry for EnTK task object

### DIFF
--- a/src/radical/entk/execman/rp/task_processor.py
+++ b/src/radical/entk/execman/rp/task_processor.py
@@ -519,6 +519,9 @@ def create_td_from_task(task, placeholders, task_hash_table, pkl_path, sid,
         if task.lfs_per_process:
             td.lfs_per_process = task.lfs_per_process
 
+        if task.mem_per_process:
+            td.mem_per_process = task.mem_per_process
+
         if task.stdout: td.stdout = task.stdout
         if task.stderr: td.stderr = task.stderr
 

--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -55,6 +55,7 @@ class Task(object):
         self._stage_on_error = False
 
         self._lfs_per_process = 0
+        self._mem_per_process = 0
         self._cpu_reqs        = {'processes'           : 1,
                                  'process_type'        : None,
                                  'threads_per_process' : 1,
@@ -63,6 +64,8 @@ class Task(object):
                                  'process_type'        : None,
                                  'threads_per_process' : 0,
                                  'thread_type'         : None}
+        
+
 
         # Data staging attributes
         self._upload_input_data    = list()
@@ -333,6 +336,15 @@ class Task(object):
         '''
 
         return self._lfs_per_process
+    
+
+    @property
+    def mem_per_process(self):
+        '''
+        Set the amount of memory space required by the task
+        '''
+
+        return self._mem_per_process
 
 
     @property
@@ -847,7 +859,16 @@ class Task(object):
             raise ree.TypeError(expected_type=int, actual_type=type(value))
 
         self._lfs_per_process = value
+    
 
+    @mem_per_process.setter
+    def mem_per_process(self, value):
+
+        if not isinstance(value, int):
+            raise ree.TypeError(expected_type=int, actual_type=type(value))
+
+        self._mem_per_process = value
+        
 
     @upload_input_data.setter
     def upload_input_data(self, value):
@@ -1040,6 +1061,8 @@ class Task(object):
             'cpu_reqs'             : self.cpu_reqs,
             'gpu_reqs'             : self.gpu_reqs,
             'lfs_per_process'      : self._lfs_per_process,
+            'mem_per_process'      : self._mem_per_process,
+
 
             'upload_input_data'    : self._upload_input_data,
             'copy_input_data'      : self._copy_input_data,

--- a/src/radical/entk/task.py
+++ b/src/radical/entk/task.py
@@ -64,7 +64,7 @@ class Task(object):
                                  'process_type'        : None,
                                  'threads_per_process' : 0,
                                  'thread_type'         : None}
-        
+
 
 
         # Data staging attributes
@@ -336,7 +336,7 @@ class Task(object):
         '''
 
         return self._lfs_per_process
-    
+
 
     @property
     def mem_per_process(self):
@@ -859,7 +859,7 @@ class Task(object):
             raise ree.TypeError(expected_type=int, actual_type=type(value))
 
         self._lfs_per_process = value
-    
+
 
     @mem_per_process.setter
     def mem_per_process(self, value):
@@ -868,7 +868,7 @@ class Task(object):
             raise ree.TypeError(expected_type=int, actual_type=type(value))
 
         self._mem_per_process = value
-        
+
 
     @upload_input_data.setter
     def upload_input_data(self, value):

--- a/tests/test_component/test_task.py
+++ b/tests/test_component/test_task.py
@@ -54,6 +54,7 @@ class TestTask(TestCase):
         self.assertIsNone(t._gpu_reqs['thread_type'])
 
         self.assertEqual(t._lfs_per_process, 0)
+        self.assertEqual(t._mem_per_process, 0)
         self.assertEqual(t._sandbox, '')
         self.assertIsInstance(t._upload_input_data, list)
         self.assertIsInstance(t._copy_input_data, list)
@@ -441,6 +442,7 @@ class TestTask(TestCase):
         t._gpu_reqs['threads_per_process'] = 0
         t._gpu_reqs['thread_type'] = 'POSIX'
         t._lfs_per_process = 0
+        t._mem_per_process = 0
         t._sandbox = ''
         t._upload_input_data = list()
         t._copy_input_data = list()
@@ -481,6 +483,7 @@ class TestTask(TestCase):
                                       'gpu_threads': 0,
                                       'gpu_thread_type': 'POSIX'},
                          'lfs_per_process': 0,
+                         'mem_per_process': 0,
                          'upload_input_data': [],
                          'copy_input_data': [],
                          'link_input_data': [],

--- a/tests/test_component/test_tproc_rp.py
+++ b/tests/test_component/test_tproc_rp.py
@@ -164,6 +164,7 @@ class TestBase(TestCase):
         mocked_TaskDescription.gpu_process_type = None
         mocked_TaskDescription.gpu_thread_type  = None
         mocked_TaskDescription.lfs_per_process  = None
+        mocked_TaskDescription.mem_per_process  = None
         mocked_TaskDescription.stdout           = None
         mocked_TaskDescription.stderr           = None
         mocked_TaskDescription.input_staging    = None
@@ -192,6 +193,7 @@ class TestBase(TestCase):
         task.tags = None
 
         task.lfs_per_process = 235
+        task.mem_per_process = 128
         task.stderr = 'stderr'
         task.stdout = 'stdout'
         hash_table = {}
@@ -214,6 +216,7 @@ class TestBase(TestCase):
         self.assertEqual(test_td.gpu_process_type, 'MPI')
         self.assertEqual(test_td.gpu_thread_type, 'MPI')
         self.assertEqual(test_td.lfs_per_process, 235)
+        self.assertEqual(test_td.mem_per_process, 128)
         self.assertEqual(test_td.stdout, 'stdout')
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
@@ -249,6 +252,7 @@ class TestBase(TestCase):
         self.assertEqual(test_td.gpu_process_type, 'POSIX')
         self.assertEqual(test_td.gpu_thread_type, 'GPU_OpenMP')
         self.assertEqual(test_td.lfs_per_process, 235)
+        self.assertEqual(test_td.mem_per_process, 128)
         self.assertEqual(test_td.stdout, 'stdout')
         self.assertEqual(test_td.stderr, 'stderr')
         self.assertEqual(test_td.input_staging, 'inputs')
@@ -277,6 +281,7 @@ class TestBase(TestCase):
         test_cud.gpu_process_type = 'POSIX'
         test_cud.gpu_thread_type  = None
         test_cud.lfs_per_process  = 235
+        test_cud.mem_per_process  = 128
         test_cud.stdout           = 'stdout'
         test_cud.stderr           = 'stderr'
         test_cud.input_staging    = 'inputs'
@@ -322,6 +327,7 @@ class TestBase(TestCase):
         test_cud.gpu_process_type = 'POSIX'
         test_cud.gpu_thread_type  = None
         test_cud.lfs_per_process  = 235
+        test_cud.mem_per_process  = 128
         test_cud.stdout           = 'stdout'
         test_cud.stderr           = 'stderr'
         test_cud.input_staging    = 'inputs'
@@ -456,6 +462,7 @@ class TestBase(TestCase):
         mocked_TaskDescription.gpu_process_type = None
         mocked_TaskDescription.gpu_thread_type  = None
         mocked_TaskDescription.lfs_per_process  = None
+        mocked_TaskDescription.mem_per_process  = None
         mocked_TaskDescription.stdout           = None
         mocked_TaskDescription.stderr           = None
         mocked_TaskDescription.input_staging    = None
@@ -511,6 +518,7 @@ class TestBase(TestCase):
         task.tags = None
 
         task.lfs_per_process = 235
+        task.mem_per_process = 128
         task.stderr = 'stderr'
         task.stdout = 'stdout'
         input_list = [{'source': 'test_file',
@@ -565,6 +573,7 @@ class TestBase(TestCase):
         self.assertEqual(test_cud.gpu_process_type, 'POSIX')
         self.assertEqual(test_cud.gpu_thread_type, 'GPU_OpenMP')
         self.assertEqual(test_cud.lfs_per_process, 235)
+        self.assertEqual(test_cud.mem_per_process, 128)
         self.assertEqual(test_cud.stdout, 'stdout')
         self.assertEqual(test_cud.stderr, 'stderr')
         self.assertEqual(test_cud.input_staging, input_list)


### PR DESCRIPTION
This PR will add an entry point for `mem_per_process` allowing the user to specify the memory required by the Task from the  `EnTK API`.