### PR TITLE
Fix codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 [run]
 concurrency = multiprocessing
 parallel = True
+omit = tests/*

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,7 +50,8 @@ jobs:
         LOC: testenv/lib/python3.6/site-packages
       run: |
         . testenv/bin/activate
-        coverage run --include=$LOC/radical/entk/* -m pytest -ra --timeout=600 -vvv --showlocals tests/test_component/ tests/test_integration/ tests/test_utils/
+        coverage run --include=$LOC/radical/entk/src/* -m pytest -ra --timeout=600 -vvv --showlocals tests/test_component/ tests/test_integration/ tests/test_utils/
+        coverage combine
         coverage xml
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,7 +50,7 @@ jobs:
         LOC: testenv/lib/python3.6/site-packages
       run: |
         . testenv/bin/activate
-        coverage run --include=$LOC/radical/entk/src/* -m pytest -ra --timeout=600 -vvv --showlocals tests/test_component/ tests/test_integration/ tests/test_utils/
+        coverage run --include=$LOC/radical/entk/* -m pytest -ra --timeout=600 -vvv --showlocals tests/test_component/ tests/test_integration/ tests/test_utils/
         coverage combine
         coverage xml
     - name: Codecov

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -51,7 +51,6 @@ jobs:
       run: |
         . testenv/bin/activate
         coverage run --include=$LOC/radical/entk/* -m pytest -ra --timeout=600 -vvv --showlocals tests/test_component/ tests/test_integration/ tests/test_utils/
-        coverage combine
         coverage xml
     - name: Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
Fix tests coverage
Currently codecov checks coverage over `tests/test_component`, besides `src/radical/entk`