### PR TITLE
Docs/no rmq

### DIFF
--- a/docs/source/dev_docs/tests.rst
+++ b/docs/source/dev_docs/tests.rst
@@ -9,12 +9,12 @@ All tests are run on a Travis. Tests are run using pytest and test coverage
 is measured using `coverage <https://coverage.readthedocs.io/>`_ and reported using `codecov <https://codecov.io>`_ .
 
 
-Unit tests test the functionality of basic methods and functions 
-offered by EnTK. We thrive to create and include a new test for every new 
+Unit tests test the functionality of basic methods and functions
+offered by EnTK. We thrive to create and include a new test for every new
 feature offered by EnTK.
 
 Integration tests test the correct communication between different EnTK components
-and packages and services used by EnTK, such as RADICAL-Pilot and Rabbit MQ.
+and packages and services used by EnTK, such as RADICAL-Pilot.
 
 Writing tests for EnTK requires to follow the `test coding guidelines <https://github.com/radical-cybertools/radical.pilot/wiki/Tests-Coding-Guidelines>`_
 of RADICAL. An example can be found `here <https://github.com/radical-cybertools/radical.entk/blob/devel/tests/test_component/test_tproc_rp.py>`_.

--- a/docs/source/entk.rst
+++ b/docs/source/entk.rst
@@ -43,7 +43,7 @@ In our PST model, we have the following objects:
 
 * **Task**: an abstraction of a computational task that contains information regarding an executable, its software environment and its data dependences.
 * **Stage**: a set of tasks without mutual dependences and that can be executed concurrently.
-* **Pipeline**: a list of stages where any stage 'i' can be executed only after stage 'i−1' has been executed.
+* **Pipeline**: a list of stages where any stage 'i' can be executed only after stage 'i--1' has been executed.
 
 When assigned to the Application Manager, the entire application can be
 expressed as a set of Pipelines. A graphical representation of an application is provided
@@ -57,7 +57,7 @@ create any application that can be expressed as a DAG.
 Architecture
 ------------
 
-EnTK sits between the user and the CI, abstracting resource management
+EnTK sits between the user and an HPC platform, abstracting resource management
 and execution management from the user.
 
 .. figure:: figures/entk_exec_model.png
@@ -71,19 +71,20 @@ and execution management from the user.
 Figure 2 shows the components (purple) and subcomponents (green) of EnTK,
 organized in three layers: API, Workflow Management, and Workload Management.
 The API layer enables users to codify PST descriptions. The Workflow Management
-layer retrieves information from the user about available CIs, initializes EnTK,
-and holds the global state of the application during execution. The Workload
-Management layer acquires resources via the RTS. The Workflow Management layer
-has two components: AppManager and WFProcessor. AppManager uses the Synchronizer
-subcomponent to update the state of the application at runtime. WFProcessor uses
-the Enqueue and Dequeue subcomponents to queue and dequeue tasks from the Task
-Management layer. The Workload Management layer uses ExecManager and its Rmgr,
-Emgr, RTS Callback, and Heartbeat subcomponents to acquire resources from CIs
-and execute the application.
+layer retrieves information from the user about available HPC platforms,
+initializes EnTK, and holds the global state of the application during
+execution. The Workload Management layer acquires resources via the RTS. The
+Workflow Management layer has two components: AppManager and WFProcessor.
+AppManager uses the Synchronizer subcomponent to update the state of the
+application at runtime. WFProcessor uses the Enqueue and Dequeue subcomponents
+to queue and dequeue tasks from the Task Management layer. The Workload
+Management layer uses ExecManager and its Rmgr, Emgr, RTS Callback, and
+Heartbeat subcomponents to acquire resources from HPC platforms and execute the
+application.
 
 This architecture is the isolation of the RTS into a stand-alone subsystem. This
 enables composability of EnTK with diverse RTS and, depending on capabilities,
-multiple types of CIs.
+multiple types of HPC platforms.
 
 
 Execution Model
@@ -107,14 +108,15 @@ state change, making it the only stateful component of EnTK.
 Failure Model
 -------------
 
-We consider four main sources of failure: EnTK components, RTS, CI, and task
-executables. All state updates in EnTK are transactional, hence any EnTK
-component that fails can be restarted at runtime without losing information
-about ongoing execution. Both the RTS and the CI are considered black boxes.
-Partial failures of their subcomponents at runtime are assumed to be handled
-locally. CI-level failures are reported to EnTK indirectly, either as failed
-pilots or failed tasks. Both pilots and tasks can be restarted. Failures are
-logged and reported to the user at runtime for live or postmortem analysis
+We consider four main sources of failure: EnTK components, RTS, HPC platform,
+and task executables. All state updates in EnTK are transactional, hence any
+EnTK component that fails can be restarted at runtime without losing information
+about ongoing execution. Both the RTS and the HPC platform are considered black
+boxes. Partial failures of their subcomponents at runtime are assumed to be
+handled locally. Platform-level failures are reported to EnTK indirectly, either
+as failed pilots or failed tasks. Both pilots and tasks can be restarted.
+Failures are logged and reported to the user at runtime for live or postmortem
+analysis
 
 
 Implementation

--- a/docs/source/entk.rst
+++ b/docs/source/entk.rst
@@ -4,9 +4,9 @@
 Ensemble Toolkit
 ****************
 
-The design and implementation of EnTK are iterative and driven by use cases. 
-Use cases span several scientific domains, including Biomolecular Sciences, 
-Material Sciences, and Earth Sciences. Users and developers collaborate to 
+The design and implementation of EnTK are iterative and driven by use cases.
+Use cases span several scientific domains, including Biomolecular Sciences,
+Material Sciences, and Earth Sciences. Users and developers collaborate to
 elicit requirements and rapid prototyping
 
 Design
@@ -22,7 +22,7 @@ by EnTK and how some of the failures are handled.
 Application Model
 -----------------
 
-We model an application by combining the Pipeline, Stage and Task (PST) 
+We model an application by combining the Pipeline, Stage and Task (PST)
 components.
 
 .. figure:: figures/pst-model.jpg
@@ -33,11 +33,11 @@ components.
  `Figure 1: PST Model`
 
 
-We consider two pythonic collections of objects, **Sets** and **Lists**, to 
-describe the task graph. A **set**-based object represents entities that have 
-**no relative order** and hence can execute independently. A **list**-based 
-object represents entities that have a linear **temporal** order, i.e. entity 
-'i' can only be operated after entity 'i-1'. 
+We consider two pythonic collections of objects, **Sets** and **Lists**, to
+describe the task graph. A **set**-based object represents entities that have
+**no relative order** and hence can execute independently. A **list**-based
+object represents entities that have a linear **temporal** order, i.e. entity
+'i' can only be operated after entity 'i-1'.
 
 In our PST model, we have the following objects:
 
@@ -47,18 +47,18 @@ In our PST model, we have the following objects:
 
 When assigned to the Application Manager, the entire application can be
 expressed as a set of Pipelines. A graphical representation of an application is provided
-in Figure 1. Note how different Pipelines can have different numbers of Stages, 
+in Figure 1. Note how different Pipelines can have different numbers of Stages,
 and different Stages can have different numbers of Tasks.
 
-By expressing your application as a *set* or *list* of such Pipelines, one can 
+By expressing your application as a *set* or *list* of such Pipelines, one can
 create any application that can be expressed as a DAG.
 
 
 Architecture
 ------------
 
-EnTK sits between the user and the CI, abstracting resource management 
-and execution management from the user. 
+EnTK sits between the user and the CI, abstracting resource management
+and execution management from the user.
 
 .. figure:: figures/entk_exec_model.png
  :width: 600pt
@@ -68,17 +68,17 @@ and execution management from the user.
  `Figure 2: Ensemble Toolkit Architecture and Execution Model`
 
 
-Figure 2 shows the components (purple) and subcomponents (green) of EnTK, 
+Figure 2 shows the components (purple) and subcomponents (green) of EnTK,
 organized in three layers: API, Workflow Management, and Workload Management.
-The API layer enables users to codify PST descriptions. The Workflow Management 
+The API layer enables users to codify PST descriptions. The Workflow Management
 layer retrieves information from the user about available CIs, initializes EnTK,
-and holds the global state of the application during execution. The Workload 
-Management layer acquires resources via the RTS. The Workflow Management layer 
+and holds the global state of the application during execution. The Workload
+Management layer acquires resources via the RTS. The Workflow Management layer
 has two components: AppManager and WFProcessor. AppManager uses the Synchronizer
 subcomponent to update the state of the application at runtime. WFProcessor uses
-the Enqueue and Dequeue subcomponents to queue and dequeue tasks from the Task 
-Management layer. The Workload Management layer uses ExecManager and its Rmgr, 
-Emgr, RTS Callback, and Heartbeat subcomponents to acquire resources from CIs 
+the Enqueue and Dequeue subcomponents to queue and dequeue tasks from the Task
+Management layer. The Workload Management layer uses ExecManager and its Rmgr,
+Emgr, RTS Callback, and Heartbeat subcomponents to acquire resources from CIs
 and execute the application.
 
 This architecture is the isolation of the RTS into a stand-alone subsystem. This
@@ -89,58 +89,47 @@ multiple types of CIs.
 Execution Model
 ---------------
 
-Once EnTK is fully initialized, WFProcessor initiates the execution by creating 
-a local copy of the application description from AppManager and tagging tasks 
+Once EnTK is fully initialized, WFProcessor initiates the execution by creating
+a local copy of the application description from AppManager and tagging tasks
 for execution. Enqueue pushes these tasks to the Pending queue (Fig. 2, 1). Emgr
-pulls tasks from the Pending queue (Fig. 2, 2) and executes them using a RTS 
-(Fig. 2, 3). RTS Callback pushes tasks that have completed execution to the 
+pulls tasks from the Pending queue (Fig. 2, 2) and executes them using a RTS
+(Fig. 2, 3). RTS Callback pushes tasks that have completed execution to the
 Done queue (Fig. 2, 4). Dequeue pulls completed tasks (Fig. 2, 5) and tags them
-as done, failed or canceled, depending on the return code of the RTS. Each 
-component and subcomponent synchronizes state transitions of pipelines, stages 
+as done, failed or canceled, depending on the return code of the RTS. Each
+component and subcomponent synchronizes state transitions of pipelines, stages
 and tasks with AppManager by pushing messages through dedicated queues (Fig. 2,
-6). AppManager pulls these messages and updates the application states. 
-AppManager then acknowledges the updates via dedicated queues (Fig. 2, 7). 
-This messaging mechanism ensures that AppManager is always up-to-date with any 
+6). AppManager pulls these messages and updates the application states.
+AppManager then acknowledges the updates via dedicated queues (Fig. 2, 7).
+This messaging mechanism ensures that AppManager is always up-to-date with any
 state change, making it the only stateful component of EnTK.
 
 
 Failure Model
 -------------
 
-We consider four main sources of failure: EnTK components, RTS, CI, and task 
-executables. All state updates in EnTK are transactional, hence any EnTK 
+We consider four main sources of failure: EnTK components, RTS, CI, and task
+executables. All state updates in EnTK are transactional, hence any EnTK
 component that fails can be restarted at runtime without losing information
-about ongoing execution. Both the RTS and the CI are considered black boxes. 
-Partial failures of their subcomponents at runtime are assumed to be handled 
-locally. CI-level failures are reported to EnTK indirectly, either as failed 
-pilots or failed tasks. Both pilots and tasks can be restarted. Failures are 
+about ongoing execution. Both the RTS and the CI are considered black boxes.
+Partial failures of their subcomponents at runtime are assumed to be handled
+locally. CI-level failures are reported to EnTK indirectly, either as failed
+pilots or failed tasks. Both pilots and tasks can be restarted. Failures are
 logged and reported to the user at runtime for live or postmortem analysis
 
 
 Implementation
 ==============
 
-EnTK is implemented in Python, uses RabbitMQ message queuing system and the 
-RADICAL-Pilot (RP) runtime system. All EnTK components are implemented as 
-processes, and all subcomponents as threads.
+EnTK is implemented in Python and uses RADICAL-Pilot (RP) as its runtime system.
+RP is designed to execute ensemble applications via pilots. Pilots provide a
+multi-stage execution mechanism: Resources are acquired via a placeholder job
+and subsequently used to execute the application's tasks. When a pilot is
+submitted to an HPC platform as a job, it waits in the platform's queue until
+the requested resources become available. At that point, the platform's
+scheduler bootstraps the job on the requested compute nodes.
 
-RabbitMQ is a server-based system and is required to be installed before the 
-execution of EnTK. This adds overheads but it also offers the following 
-benefits: (1) producers and consumers do not need to be topology aware because 
-they interact only with the server; (2) messages are stored in the server and
-can be recovered upon failure of EnTK components; and (3) messages can be pushed
-and pulled asynchronously because data can be buffered by the server upon 
-production.
-
-RP is a runtime system designed to execute ensemble applications via pilots. 
-Pilots provide a multi-stage execution mechanism: Resources are acquired via a 
-placeholder job and subsequently used to execute the application’s tasks. When a
-pilot is submitted to a CI as a job, it waits in the CI’s queue until the 
-requested resources become available. At that point, the CI’s scheduler 
-bootstraps the job on the CI’s compute nodes.
-
-You can view the :ref:`class diagram <dev_docs_cls_diag>` and 
-:ref:`sequence diagram <dev_docs_seq_diag>` and more in the 
+You can view the :ref:`class diagram <dev_docs_cls_diag>` and
+:ref:`sequence diagram <dev_docs_seq_diag>` and more in the
 :ref:`developer documentation <dev_docs>`.
 
 
@@ -152,7 +141,7 @@ Performance
 Below we present the weak and strong scaling behavior of EnTK on the ORNL
 Titan machine.
 
-Detailed description of the experiments can be found in this 
+Detailed description of the experiments can be found in this
 `technical paper <https://arxiv.org/pdf/1710.08491>`_.
 
 .. figure:: figures/weak_scaling_titan_orte.png

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -5,8 +5,8 @@
 Examples
 ********
 
-The following is a list of common application structures. Please read both the 
-description in the website as well as comments made in the python scripts.
+The following is a list of common application structures. Please read both the
+description on the website and the comments made in the python scripts.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,8 +18,6 @@ Open a terminal and run:
         virtualenv $HOME/ve-entk -p python3.7
 
 - ``-p`` params indicates which python version you use, python3.7+ is required
-- A legacy python2 installation is available with the ``0.72.1`` version. Hot fixes will be provided until Jul 2020. Read more at
-  the troubleshooting_
 
 Activate virtualenv by:
 
@@ -161,130 +159,13 @@ be printed.
                 0.70.0
 
 
-
-RabbitMQ
-========
-
-Ensemble Toolkit relies on RabbitMQ for message transfers. Users have three
-choices: (1) self-deploying and using a local RabbiMQ server; (2) self-deploying
-and using a remote RabbitMQ server that is accessible from the target HPC
-machine; (3) use a local or remote RabbitMQ server provided by the HPC
-organization or by an external partner. Note that most HPC infrastructures
-forbid executing servers on their login nodes. If you have no other option,
-please open an issue on the `EnTK GitHub repository
-<https://github.com/radical-cybertools/radical.entk/issues>`_ and we will provide
-you with a testing account on our RabbitMQ server.
-
-In case, installation instructions can be found at
-<https://www.rabbitmq.com/download.html>. At the end of the installation, do not
-forget to run ```rabbitmq-server``` to start the server.
-
-The following configuration defines a default server and port number to
-communicate. Note that remote RabbitMQ servers may require username and
-password. If you are using one of the RADICAL servers, username and password
-are mandatory.
-
-.. code-block:: bash
-
-        export RMQ_HOSTNAME={IP ADDRESS};
-        export RMQ_PORT={PORT NUMBER};
-        export RMQ_USERNAME={USERNAME};
-        export RMQ_PASSWORD={PASSWORD};
-
-.. note:: {} sections need to be replaced with actual values, and EnTK
-        administrators are able to provide these information.
-
-If RabbitMQ is enabled via virtual hosts, there is an option to specify the
-vhost information through additional environment variables :
-
-.. code-block:: bash
-
-        export RMQ_SSL=True
-        export RMQ_VHOST=/vhost_name
-
-You may replace `/vhost_name` with an actual name of a virtual host. The other
-information (i.e., username and password) to connect to RabbitMQ stays same but
-uses this specific vhost name to authenticate.
-
-RMQ Account
------------
-
-Open a new ticket asking a new RMQ account:
-https://github.com/radical-cybertools/radical.entk/issues
-
-.. comments
-
-        Installing rabbitmq
-        ===================
-
-        Installing rabbitmq as a system process (sudo privileges required)
-        ------------------------------------------------------------------
-
-        Ensemble Toolkit relies on RabbitMQ for message transfers. Installation
-        instructions can be found at <https://www.rabbitmq.com/download.html>. At
-        the end of the installation run ```rabbitmq-server``` to start the server.
-        RabbitMQ needs to be installed on the same machine as EnTK is installed.
-
-        In some cases, you might have to explicitly start the rabbitmq-server after
-        installation. You can check if the rabbitmq-server process is alive. If not,
-        please run the following:
-
-        .. code-block:: bash
-
-                rabbitmq-server -detached
-
-
-        Installing rabbitmq using docker
-        --------------------------------
-
-        If installing rabbitmq directly seems to be cumbersome, you can also install a
-        docker instance of rabbitmq. Assuming you have docker installed, you can
-        download and run the rabbitmq instance using the following command:
-
-        .. code-block:: bash
-
-                docker run -d --name <name of instance> -P rabbitmq:3
-
-
-        The '-P' argument auto maps new ports from localhost to the ports expected by
-        rabbitmq. This is useful if you want to have multiple EnTK scripts running as
-        you would require multiple rabbitmq instances.
-
-        You can see the mapping of the ports running ```docker ps```.
-
-        .. code-block:: bash
-
-                vivek@two:~$ docker run -d --name rabbit-1 -P rabbitmq:3
-                fb8ee8bfd822656a6338b7c19fa6a9641944f8bf5de5c1414fb78d049fdffc42
-                vivek@two:~$ docker ps
-                CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                                                                                 NAMES
-                fb8ee8bfd822        rabbitmq:3          "docker-entrypoint..."   9 seconds ago       Up 7 seconds        0.0.0.0:32777->4369/tcp, 0.0.0.0:32776->5671/tcp, 0.0.0.0:32775->5672/tcp, 0.0.0.0:32774->25672/tcp   rabbit-1
-
-
-        Interactions between RabbitMQ and EnTK are done through port 5672 by default.
-        For the above docker instance, we need to use port 32775. In your EnTK scripts,
-        while creating the AppManager, you need to specify port=32775.
-
-        .. note::
-           If you are using Docker to install both EnTK and RabbitMQ, they should run
-           as two different containers. You can set the RMQ_PORT in the EnTK container
-           accordingly.
-
-        Installation Video
-        ==================
-
-        .. raw:: html
-
-                <video controls width="800" src="_static/entk_installation_get_started.mp4"></video>
-
-
 Preparing the Environment
 =========================
 
 Ensemble Toolkit uses `RADICAL Pilot <http://radicalpilot.readthedocs.org>`_ as
-the runtime system. RADICAL Pilot can access HPC clusters remotely via SSH and
-GSISSH, but it requires (a) a MongoDB server and (b) a properly set-up
-passwordless SSH/GSISSH environment.
+the runtime system. RADICAL Pilot can access HPC clusters remotely via SSH but
+it requires: (1) a MongoDB server; and (2) a properly set-up passwordless SSH
+environment.
 
 
 .. comments
@@ -335,17 +216,20 @@ passwordless SSH/GSISSH environment.
 
 .. _ssh_gsissh_setup:
 
-Setup passwordless SSH Access to HPC resources
+Setup passwordless SSH Access to HPC platforms
 ----------------------------------------------
 
-In order to create a passwordless access to another machine, you need to create a RSA key on your local machine
-and paste the public key into the `authorizes_users` list on the remote machine.
+In order to create a passwordless access to another machine, you need to create
+a key-pair on your local machine and paste the public key into the
+`authorizes_users` list on the remote machine.
 
-`This <http://linuxproblem.org/art_9.html>`_ is a recommended tutorial to create password ssh access.
+`This <http://linuxproblem.org/art_9.html>`_ is a recommended tutorial to create
+password ssh access.
 
-An easy way to setup SSH access to multiple remote machines is to create a file ``~/.ssh/config``.
-Suppose the url used to access a specific machine is ``foo@machine.example.com``. You can create an entry in this
-config file as follows:
+An easy way to setup SSH access to multiple remote machines is to create a file
+``~/.ssh/config``. Suppose the URL used to access a specific machine is
+``foo@machine.example.com``. You can create an entry in this config file as
+follows:
 
 .. code-block:: bash
 
@@ -358,19 +242,6 @@ Now you can login to the machine by ``ssh machine1``.
 
 
 Source: http://nerderati.com/2011/03/17/simplify-your-life-with-an-ssh-config-file/
-
-
-Setup GSISSH Access to HPC resources
-------------------------------------
-
-Setting up GSISSH access to a machine is a bit more complicated. We have documented the steps to setup GSISSH on
-`Ubuntu <https://github.com/vivek-bala/docs/blob/master/misc/gsissh_setup_stampede_ubuntu_xenial.sh>`_ (tested for
-trusty and xenial) and `Mac <https://github.com/vivek-bala/docs/blob/master/misc/gsissh_setup_mac>`_. Simply execute
-all the commands, see comments for details.
-
-The above links document the overall procedure and how to get certificates to access XSEDE machines. Depending on the machine
-you want to access, you will have to get the certificates from the corresponding locations. In most cases, this
-information is available in their user guide.
 
 
 .. _troubleshooting:
@@ -391,31 +262,3 @@ If virtualenv **is not** installed on your system, you can try the following.
 
         python virtualenv-16.7.9/virtualenv.py $HOME/ve-entk -p python3.7
         source $HOME/ve-entk/bin/activate
-
-**Python 2 legacy installation**
-
-As of January 1, 2020, Python 2 support is terminated by the Python Software
-Foundation but the previous release of EnTK i.e. ``0.72.1`` allows to use Python 2.7.
-PyPI installation with virtualenv is:
-
-.. code-block:: bash
-
-        virtualenv $HOME/ve-entk-py2 -p python2.7
-        source $HOME/ve-entk-py2/bin/activate
-        pip install radical.entk==0.72.1
-
-```radical-stack``` confirms the versions of the radical cybertools:
-
-.. code-block:: bash
-
-        $ radical-stack
-
-          python               : 2.7.17
-          pythonpath           :
-          virtualenv           : /home/username/ve-entk-py2
-
-          radical.entk         : 0.72.1
-          radical.pilot        : 0.73.1
-          radical.saga         : 0.72.1
-          radical.utils        : 0.72.0
-

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -112,52 +112,6 @@ be printed.
           radical.utils        : 1.6.2
 
 
-.. comments
-
-        Installing Ensemble Toolkit using Docker
-        ----------------------------------------
-
-        You can install Docker from their
-        `official documentation <https://hub.docker.com/search/?type=edition&offering=community>`_.
-        Once you have installed Docker, you can use the following Dockerfile to build
-        a container:
-
-        .. code-block:: bash
-
-                FROM ubuntu:16.04
-
-                ENV RMQ_HOSTNAME=two.radical-project.org
-                ENV RMQ_PORT=33247
-                ENV RADICAL_PILOT_DBURL="mongodb://user:user@ds247688.mlab.com:47688/entk-docs"
-
-                RUN apt-get update \
-                && apt-get install wget curl python python-dev python-pip python-virtualenv bzip2 -y \
-                && virtualenv ~/ve-entk \
-                && . ~/ve-entk/bin/activate \
-                && pip install radical.entk
-
-        You can also download the Dockerfile :download:`here <./misc/Dockerfile>`.
-
-        You can build and execute the container by running:
-
-        .. code-block:: bash
-
-                docker build -f ./Dockerfile -t entk .
-                docker run -t -i entk
-
-        Once you execute the container, the default path will be /root (of the container).
-        The EnTK virtualenv exists at ~/ve-entk (inside the container). This is useful
-        to know as the examples exist inside the virtualenv.
-
-        You can check the version of Ensemble Toolkit with the
-        ```radical-entk-version``` command-line tool. The current version should be
-        printed.
-
-        .. code-block:: bash
-
-                radical-entk-version
-                0.70.0
-
 
 Preparing the Environment
 =========================
@@ -166,53 +120,6 @@ Ensemble Toolkit uses `RADICAL Pilot <http://radicalpilot.readthedocs.org>`_ as
 the runtime system. RADICAL Pilot can access HPC clusters remotely via SSH but
 it requires: (1) a MongoDB server; and (2) a properly set-up passwordless SSH
 environment.
-
-
-.. comments
-
-        MongoDB Server
-        --------------
-
-        .. figure:: figures/hosts_and_ports.png
-             :width: 360pt
-             :align: center
-             :alt: MongoDB and SSH ports.
-
-        The MongoDB server is used to store and retrieve operational data during the
-        execution of an application using RADICAL-Pilot. The MongoDB server must
-        be reachable on **port 27017** from **both**, the host that runs the
-        Ensemble Toolkit application and the host that executes the MD tasks, i.e.,
-        the HPC cluster (see blue arrows in the figure above). In our experience,
-        a small VM instance (e.g., Amazon AWS) works exceptionally well for this.
-
-        .. warning:: If you want to run your application on your laptop or private
-                    workstation, but run your MD tasks on a remote HPC cluster,
-                    installing MongoDB on your laptop or workstation won't work.
-                    Your laptop or workstation usually does not have a public IP
-                    address and is hidden behind a masked and firewalled home or office
-                    network. This means that the components running on the HPC cluster
-                    will not be able to access the MongoDB server.
-
-        A MongoDB server can support more than one user. In an environment where
-        multiple users use Ensemble Toolkit, a single MongoDB server
-        for all users / hosts is usually sufficient.
-
-        **Install your own MongoDB**
-
-        Once you have identified a host that can serve as the new home for MongoDB,
-        installation is straight forward. You can either install the MongoDB
-        server package that is provided by most Linux distributions, or
-        follow the installation instructions on the MongoDB website:
-
-        http://docs.mongodb.org/manual/installation/
-
-        **MongoDB-as-a-Service**
-
-        There are multiple commercial providers of hosted MongoDB services, some of them
-        offer free usage tiers. We have had some good experience with the following:
-
-        * https://mongolab.com/
-
 
 .. _ssh_gsissh_setup:
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -8,22 +8,22 @@ Overview
 ========
 
 
-The Ensemble Toolkit is a Python framework for developing and executing 
-applications comprised of multiple sets of tasks, aka ensembles. Ensemble 
-Toolkit was originally developed with ensemble-based applications in mind. As 
-our understanding of the variety of workflows in scientific application 
-improved, we realized our approach needs to be more generic. Although our 
-motivation remains that of Ensemble-based applications, from EnTK 0.6 onwards, 
-any application where the task workflow can be expressed as a Directed Acyclic 
+The Ensemble Toolkit is a Python framework for developing and executing
+applications comprised of multiple sets of tasks, aka ensembles. Ensemble
+Toolkit was originally developed with ensemble-based applications in mind. As
+our understanding of the variety of workflows in scientific application
+improved, we realized our approach needs to be more generic. Although our
+motivation remains that of Ensemble-based applications, from EnTK 0.6 onwards,
+any application where the task workflow can be expressed as a Directed Acyclic
 Graph, can be supported.
 
-The Ensemble Toolkit has the following unique features: (i) abstractions that 
-enable the expression of various task graphs, (ii) abstraction of resource 
+The Ensemble Toolkit has the following unique features: (i) abstractions that
+enable the expression of various task graphs, (ii) abstraction of resource
 management and task execution, (iii) Fault tolerance as a first order concern
-and (iv) well-established runtime capabilities to enable efficient and dynamic 
+and (iv) well-established runtime capabilities to enable efficient and dynamic
 usage of grid resources and supercomputers.
 
-We will now discuss the high level design of Ensemble Toolkit in order to 
+We will now discuss the high level design of Ensemble Toolkit in order to
 understand how an application is created and executed.
 
 Design
@@ -37,34 +37,34 @@ Design
    `Figure 1: High level design of Ensemble Toolkit`
 
 
-Ensemble toolkit consists of several components that serve different purposes. 
-There are three user level components, namely, Pipeline, Stage and Task, that 
-are used directly by the user. The **Pipeline**, **Stage** and **Task** are 
-components used to create the application by describing its task graph. We will 
+Ensemble toolkit consists of several components that serve different purposes.
+There are three user level components, namely, Pipeline, Stage and Task, that
+are used directly by the user. The **Pipeline**, **Stage** and **Task** are
+components used to create the application by describing its task graph. We will
 soon take a look into how these can be used to create an application.
 
-The **Application Manager** is an internal component, that takes a workflow 
+The **Application Manager** is an internal component, that takes a workflow
 described by the user and converts it into a set of **workloads**, i.e. tasks
-with no dependencies by parsing through the workflow and identifying, during 
+with no dependencies by parsing through the workflow and identifying, during
 runtime, tasks with equivalent or no dependencies. The Application Manager
 also accepts the description of the resource request (with resource
 label, walltime, cpus, gpus, user credentials) to be created.
 
-The **Execution Manager** is the last component in Ensemble Toolkit. It 
-accepts the workloads prepared by the Application Manager and executes them on 
-the specified resource using a Runtime system (RTS). Internally, it consists of 
+The **Execution Manager** is the last component in Ensemble Toolkit. It
+accepts the workloads prepared by the Application Manager and executes them on
+the specified resource using a Runtime system (RTS). Internally, it consists of
 two subcomponents: ResourceManager and TaskManager, that are responsible for the
 allocation, management, and deallocation of resources, and execution management
 of tasks, respectively. The Execution Manager is currently configured to use
-`RADICAL Pilot (RP) <http://radicalpilot.readthedocs.org>`_ as the runtime 
+`RADICAL Pilot (RP) <http://radicalpilot.readthedocs.org>`_ as the runtime
 system, but can be extended to other RTS.
 
-Ensemble Toolkit uses a runtime system as a framework to simply execute tasks 
-on computing infrastructures (CIs). The runtime system is expected to manage 
-the direct interactions with the various software and hardware layers of the 
-CIs, including the heterogeneity amongst various CIs.
+Ensemble Toolkit uses a runtime system as a framework to simply execute tasks on
+high performance computing (HPC) platforms. The runtime system is expected to
+manage the direct interactions with the various software and hardware layers of
+the HPC platforms, including their heterogeneitys.
 
-More details about how EnTK is designed and implemented can be found 
+More details about how EnTK is designed and implemented can be found
 :ref:`here <entk>`.
 
 .. _dependency:
@@ -72,24 +72,20 @@ More details about how EnTK is designed and implemented can be found
 Dependencies
 ------------
 
-Ensemble Toolkit uses `RADICAL Pilot (RP) <http://radicalpilot.readthedocs.org>`_ 
-as the runtime system. RP is targeted currently only for a set of high 
-performance computing (HPC) systems 
-(`see here <http://radicalpilot.readthedocs.io/en/stable/resources.html#chapter-resources>`_). 
-RP can be extended to support more HPC systems by contacting the developers of 
-RP/EnTK or by the user themselves by following 
+Ensemble Toolkit uses `RADICAL Pilot (RP) <http://radicalpilot.readthedocs.org>`_
+as the runtime system. RP is targeted currently only for a set of high
+performance computing (HPC) systems
+(`see here <http://radicalpilot.readthedocs.io/en/stable/resources.html#chapter-resources>`_).
+RP can be extended to support more HPC systems by contacting the developers of
+RP/EnTK or by the user themselves by following
 `this page <http://radicalpilot.readthedocs.io/en/stable/machconf.html#writing-a-custom-resource-configuration-file>`_.
 
-Ensemble Toolkit also relies on RabbitMQ to support messaging capabilities 
-between its various components. Read more about it `here <http://www.rabbitmq.com/>`_.
-
-EnTK also has profiling capabilities and uses `Pandas <https://pandas.pydata.org/>`_ 
+EnTK also has profiling capabilities and uses `Pandas <https://pandas.pydata.org/>`_
 dataframes to store the data. Users can use these dataframes to wrangle the data
 or directly plot the required fields.
 
-Dependencies such as RP and Pandas are automatically installed when installing 
-EnTK. RabbitMQ, on the other hand, needs to be installed manually by the user.
-Instructions are provided :ref:`here <installation>`.
+Dependencies such as RP and Pandas are automatically installed when installing
+EnTK.
 
 Five steps to create an application
 -----------------------------------
@@ -100,21 +96,17 @@ Five steps to create an application
 4. Run the Application Manager.
 5. Sit back and relax!
 
-Jump ahead to take a look at the step by step instructions for an example
+Jump ahead to take a look at the step-by-step instructions for an example
 script :ref:`here <uguide_get_started>`.
 
 Intended users
 ==============
 
-Ensemble Toolkit is completely Python based and requires familiarity with the 
-Python language. 
+Ensemble Toolkit is completely Python based and requires familiarity with the
+Python language.
 
-Our primary focus is to support domain scientists and enable them to execute 
-their applications at scale on various CIs. This, however, does not mean that this 
-framework cannot be used by users with simpler requirements. Consider using EnTK for
-its automation and fault-tolerance capabilities, even if it requires no HPC (even on your personal PC!).
-
-Some of our current users are mentioned below.
+Our primary focus is to support domain scientists and enable them to execute
+their applications at scale on various HPC platforms. Some of our include:
 
 +------------------------+---------------+
 | User Groups            |   Domain      |

--- a/docs/source/user_guide/adding_shared_data.rst
+++ b/docs/source/user_guide/adding_shared_data.rst
@@ -5,9 +5,11 @@
 Adding Shared Data
 ******************
 
-Data management is one of the important elements of any application. In many applications, there exist an initial set of
-files, common to multiple tasks, that need to be transfered, once, to the remote machine.  In this section, we will take
-a look at how we can manage data shared between multiple tasks to the remote machine by a one-time transfer.
+Data management is one of the important elements of any application. In many
+applications, there exist an initial set of files, common to multiple tasks,
+that need to be transferred, once, to the remote machine.  In this section, we
+will take a look at how we can manage data shared between multiple tasks to the
+remote machine by a one-time transfer.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through
             the :ref:`introduction` of Ensemble Toolkit.
@@ -18,10 +20,11 @@ a look at how we can manage data shared between multiple tasks to the remote mac
 You can download the complete code discussed in this section :download:`here <../../../examples/user_guide/add_shared_data.py>`
 or find it in your virtualenv under ``share/radical.entk/user_guide/scripts``.
 
-In the following example, we will create a Pipeline with one Stage and 10 tasks. The tasks concatenate two input files
-and write the standard output to a file. Since the two input files are common between all the tasks, it will be efficient
-to transfer those files only once to the remote machine and have the tasks copy the input files when being
-executed.
+In the following example, we will create a Pipeline with one Stage and 10 tasks.
+The tasks concatenate two input files and write the standard output to a file.
+Since the two input files are common between all the tasks, it will be efficient
+to transfer those files only once to the remote machine and have the tasks copy
+the input files when being executed.
 
 Users can specify such shared data using the ``shared_data`` attribute of the AppManager object.
 
@@ -31,24 +34,25 @@ Users can specify such shared data using the ``shared_data`` attribute of the Ap
     :dedent: 4
 
 
-The shared data can then be referenced for copying or linking using the ``$SHARED`` keyword for specifying the
-file movement description of the task.
+The shared data can then be referenced for copying or linking using the
+``$SHARED`` keyword for specifying the file movement description of the task.
 
 .. literalinclude:: ../../../examples/user_guide/add_shared_data.py
     :language: python
     :lines: 30-35
     :dedent: 4
 
-In the example provided, the two files contain the words 'Hello' and 'World', respectively, and the output files
-are expected to contain 'Hello World'
+In the example provided, the two files contain the words 'Hello' and 'World',
+respectively, and the output files are expected to contain 'Hello World'
 
 .. code-block:: bash
 
     python add_shared_data.py
 
 
-Let's take a look at the complete code in the example. You can generate a more verbose output by setting the environment
-variable ``RADICAL_ENTK_VERBOSE=DEBUG``.
+Let's take a look at the complete code in the example. You can generate a more
+verbose output by setting the environment variable
+``RADICAL_ENTK_VERBOSE=DEBUG``.
 
 
 A look at the complete code in this section:

--- a/docs/source/user_guide/adding_tasks.rst
+++ b/docs/source/user_guide/adding_tasks.rst
@@ -5,8 +5,8 @@
 Adding Tasks
 ************
 
-In this section, we will take a look at how we can add more tasks to our base script from the
-:ref:`Getting Started <uguide_get_started>` section.
+In this section, we will take a look at how we can add more tasks to our base
+script from the :ref:`Getting Started <uguide_get_started>` section.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through
     the :ref:`introduction` of Ensemble Toolkit.
@@ -16,8 +16,8 @@ In this section, we will take a look at how we can add more tasks to our base sc
 You can download the complete code discussed in this section :download:`here <../../../examples/user_guide/add_tasks.py>`
 or find it in your virtualenv under ``share/radical.entk/user_guide/scripts``.
 
-Below, you can see the code snippet that shows how you can create more Task objects
-and **add** them to the Stage using the **add_task()** method.
+Below, you can see the code snippet that shows how you can create more Task
+objects and **add** them to the Stage using the **add_task()** method.
 
 .. literalinclude:: ../../../examples/user_guide/add_tasks.py
     :language: python

--- a/docs/source/user_guide/change_target.rst
+++ b/docs/source/user_guide/change_target.rst
@@ -5,13 +5,13 @@
 Changing Target Machine
 ***********************
 
-All of our examples so far have been run locally. Its time to run something on
-a HPC! One of the features of Ensemble Toolkit is that you can submit tasks on
-another machine remotely from your local machine. But this has some requirements,
-you need to have passwordless ssh or gsissh access to the target machine. If you
-don't have such access, we discuss the setup :ref:`here <ssh_gsissh_setup>`. You
-also need to confirm that RP and Ensemble Toolkit are supported on this machine.
-A list of supported machines and how to get support for new machines is
+All of our examples so far have been run locally. Its time to run something on a
+HPC! One of the features of Ensemble Toolkit is that you can submit tasks on
+another machine remotely from your local machine. But this has some
+requirements, you need to have passwordless ssh access to the target machine. If
+you don't have such access, we discuss the setup :ref:`here <ssh_gsissh_setup>`.
+You also need to confirm that RP and Ensemble Toolkit are supported on this
+machine. A list of supported machines and how to get support for new machines is
 discussed :ref:`here <entk>`.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through
@@ -20,9 +20,11 @@ discussed :ref:`here <entk>`.
 .. note:: This chapter assumes that you have successfully installed Ensemble Toolkit, if not see :ref:`Installation`.
 
 
-Once you have passwordless access to another machine, switching from one target machine to another is quite simple.
-We simply re-describe the resource dictionary that is used to create the Resource Manager. For example, in order to
-run on the XSEDE Stampede cluster, we describe the resource dictionary as follows:
+Once you have passwordless access to another machine, switching from one target
+machine to another is quite simple. We simply re-describe the resource
+dictionary that is used to create the Resource Manager. For example, in order to
+run on the ACCESS Stampede cluster, we describe the resource dictionary as
+follows:
 
 .. literalinclude:: ../../../examples/user_guide/change_target.py
     :language: python

--- a/docs/source/user_guide/get_started.rst
+++ b/docs/source/user_guide/get_started.rst
@@ -5,8 +5,8 @@
 Getting Started
 ***************
 
-In this section we will run through the Ensemble Toolkit API.
-We will develop an example application consisting of a simple bag of Tasks.
+In this section we will run through the Ensemble Toolkit API. We will develop an
+example application consisting of a simple bag of Tasks.
 
 .. note:: The reader is assumed to be familiar with the :ref:`PST Model <app_model>` and to have read through the :ref:`introduction` of Ensemble Toolkit.
 
@@ -19,7 +19,9 @@ your virtualenv under ``share/radical.entk/user_guide/scripts``.
 Importing components from the Ensemble Toolkit Module
 ===========================================================
 
-To create any application using Ensemble Toolkit, you need to import five modules: Pipeline, Stage, Task, AppManager, ResourceManager. We have already discussed these components in the earlier sections.
+To create any application using Ensemble Toolkit, you need to import five
+modules: Pipeline, Stage, Task, AppManager, ResourceManager. We have already
+discussed these components in the earlier sections.
 
 .. literalinclude:: ../../../examples/user_guide/get_started.py
     :language: python
@@ -31,8 +33,9 @@ Creating the workflow
 =====================
 
 
-We first create a Pipeline, Stage and Task object. Then we assign the 'executable' and 'arguments' for the Task. For
-this example, we will create one Pipeline consisting of one Stage that contains one Task.
+We first create a Pipeline, Stage and Task object. Then we assign the
+'executable' and 'arguments' for the Task. For this example, we will create one
+Pipeline consisting of one Stage that contains one Task.
 
 In the below snippet, we first create a Pipeline then a Stage.
 
@@ -42,7 +45,8 @@ In the below snippet, we first create a Pipeline then a Stage.
     :linenos:
     :lineno-start: 22
 
-Next, we create a Task and assign its name, executable and arguments of the executable.
+Next, we create a Task and assign its name, executable and arguments of the
+executable.
 
 .. literalinclude:: ../../../examples/user_guide/get_started.py
     :language: python
@@ -51,8 +55,8 @@ Next, we create a Task and assign its name, executable and arguments of the exec
     :lineno-start: 30
 
 
-Now, that we have a fully described Task, a Stage and a Pipeline. We create our workflow by adding the Task to the
-Stage and adding the Stage to the Pipeline.
+Now, that we have a fully described Task, a Stage and a Pipeline. We create our
+workflow by adding the Task to the Stage and adding the Stage to the Pipeline.
 
 .. literalinclude:: ../../../examples/user_guide/get_started.py
     :language: python
@@ -64,10 +68,11 @@ Stage and adding the Stage to the Pipeline.
 Creating the AppManager
 =======================
 
-Now that our workflow has been created, we need to specify where it is to be executed. For this example, we will
-simply execute the workflow locally. We create an AppManager object, describe a resource request for 1 core for 10
-minutes on localhost, i.e. your local machine. We assign the resource request description and the workflow to the
-AppManager and ``run`` our application.
+Now that our workflow has been created, we need to specify where it is to be
+executed. For this example, we will simply execute the workflow locally. We
+create an AppManager object, describe a resource request for 1 core for 10
+minutes on localhost, i.e. your local machine. We assign the resource request
+description and the workflow to the AppManager and ``run`` our application.
 
 .. literalinclude:: ../../../examples/user_guide/get_started.py
     :language: python
@@ -98,17 +103,18 @@ To run the script, simply execute the following from the command line:
         avoid to raise that exception.
 
 
-And that's it! That's all the steps in this example. You can generate more verbose output
-by setting the environment variable **`export  RADICAL_LOG_TGT=radical.log;export RADICAL_LOG_LVL=DEBUG`**.
+And that's it! That's all the steps in this example. You can generate more
+verbose output by setting the environment variable **`export
+RADICAL_LOG_TGT=radical.log;export RADICAL_LOG_LVL=DEBUG`**.
 
 After the execution of the example, you may want to check the output. Under your
-home folder, you will find a folder named `radical.pilot.sandbox`. In that folder,
-there will be a `re.session.*` folder and a `ve.local.localhost` folder. Inside,
-`re.session.*`, there is a `pilot.0000` folder and in there a `unit.000000` folder.
-In the unit folder, you will see several files including a `unit.000000.out` and
-`unit.000000.err` files. The `unit.000000.out` holds the messages from the standard
-output and `unit.000000.err` holds the messages from standard error. The `unit.000000.out`
-file should have a `Hello World` message.
+home folder, you will find a folder named `radical.pilot.sandbox`. In that
+folder, there will be a `re.session.*` folder and a `ve.local.localhost` folder.
+Inside, `re.session.*`, there is a `pilot.0000` folder and in there a
+`unit.000000` folder. In the unit folder, you will see several files including a
+`unit.000000.out` and `unit.000000.err` files. The `unit.000000.out` holds the
+messages from the standard output and `unit.000000.err` holds the messages from
+standard error. The `unit.000000.out` file should have a `Hello World` message.
 
 Let's look at the complete code for this example:
 


### PR DESCRIPTION
Eliminates RabbitMQ from the documentation and some scattered cleanup (outdated use of CI, comments, legacy version, etc.)